### PR TITLE
Add verified page activation and native wheel input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,14 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
 
+      - name: Verify release tag matches package version
+        run: |
+          version="$(cargo pkgid -p ab-mcp | sed -E 's/.*[#@]//')"
+          test "v${version}" = "${GITHUB_REF_NAME}" || {
+            echo "release tag ${GITHUB_REF_NAME} does not match ab-mcp version v${version}" >&2
+            exit 1
+          }
+
       - name: Build
         run: cargo build --release --target ${{ matrix.target }} -p ab-mcp
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ab-browser"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "ab-cdp",
  "anyhow",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "ab-cdp"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "futures-util",
  "serde",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "ab-mcp"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "ab-browser",
  "ab-cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/ab-cdp", "crates/ab-browser", "crates/ab-mcp"]
 
 [workspace.package]
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 browser-rs is a lightweight, stealth-oriented browser MCP server. It lets
 multiple AI agents share one logged-in Chrome — each agent controls only its
 own tabs — for parallel scraping, web automation, and QA without every agent
-spinning up its own browser. 62 Playwright-style tools, one Rust binary, no
+spinning up its own browser. 64 Playwright-style tools, one Rust binary, no
 Node.js runtime.
 
 ```mermaid
@@ -126,11 +126,18 @@ and capability-header details are in **[INSTALL.md](INSTALL.md)**.
 
 ## Tools
 
-MCP exposes 62 `browser_*` tools:
+MCP exposes 64 `browser_*` tools:
 
-**Navigation and inspection:** `browser_navigate` · `browser_new_page` · `browser_snapshot` · `browser_read` · `browser_get_visible_html` · `browser_get_visible_text` · `browser_find` · `browser_take_screenshot` · `browser_save_pdf` · `browser_pages` · `browser_tabs` · `browser_switch_page` · `browser_profile` · `browser_status`
+**Navigation and inspection:** `browser_navigate` · `browser_new_page` · `browser_snapshot` · `browser_activate_page` · `browser_read` · `browser_get_visible_html` · `browser_get_visible_text` · `browser_find` · `browser_take_screenshot` · `browser_save_pdf` · `browser_pages` · `browser_tabs` · `browser_switch_page` · `browser_profile` · `browser_status`
 
-**Interaction:** `browser_click` · `browser_type` · `browser_press_key` · `browser_hover` · `browser_select_option` · `browser_fill_form` · `browser_drag` · `browser_file_upload` · `browser_navigate_back` · `browser_wait_for` · `browser_resize` · `browser_evaluate` · `browser_run_code_unsafe` · `browser_iframe_click` · `browser_iframe_fill` · `browser_close_page` · `browser_close`
+**Interaction:** `browser_click` · `browser_wheel` · `browser_type` · `browser_press_key` · `browser_hover` · `browser_select_option` · `browser_fill_form` · `browser_drag` · `browser_file_upload` · `browser_navigate_back` · `browser_wait_for` · `browser_resize` · `browser_evaluate` · `browser_run_code_unsafe` · `browser_iframe_click` · `browser_iframe_fill` · `browser_close_page` · `browser_close`
+
+Use `browser_activate_page({ "page": "p5" })` before automating a background
+tab whose site throttles lazy loading. It calls CDP `Target.activateTarget`,
+retries visibility/focus verification, and uses a process-specific macOS
+foreground fallback when browser-rs launched Chrome itself. Use
+`browser_wheel({ "page": "p5", "delta_y": 700, "x": 650, "y": 500 })` for a
+real CDP `mouseWheel` event instead of DOM `window.scrollBy()`.
 
 **Network and requests:** `browser_network_requests` · `browser_route_block` · `browser_route_mock` · `browser_route_clear` · `browser_network_state_set` · `browser_api_request`
 

--- a/crates/ab-browser/src/lib.rs
+++ b/crates/ab-browser/src/lib.rs
@@ -421,11 +421,21 @@ impl Page {
             }
             tokio::time::sleep(Duration::from_millis(100 * u64::from(attempts))).await;
 
-            let state = self
+            let state = match self
                 .evaluate(
                     "({visibility: document.visibilityState, windowFocused: document.hasFocus()})",
                 )
-                .await?;
+                .await
+            {
+                Ok(state) => state,
+                Err(error) if attempts < 3 => {
+                    debug!(
+                        "page activation visibility check failed on attempt {attempts}: {error}"
+                    );
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
             visibility = state
                 .get("visibility")
                 .and_then(Value::as_str)

--- a/crates/ab-browser/src/lib.rs
+++ b/crates/ab-browser/src/lib.rs
@@ -446,7 +446,7 @@ impl Page {
                 .and_then(Value::as_bool)
                 .unwrap_or(false);
 
-            if visibility == "visible" && window_focused {
+            if activation_verified(&visibility, window_focused) {
                 return Ok(PageActivation {
                     activated: true,
                     visibility,
@@ -457,7 +457,7 @@ impl Page {
         }
 
         Ok(PageActivation {
-            activated: visibility == "visible",
+            activated: activation_verified(&visibility, window_focused),
             visibility,
             window_focused,
             attempts: 3,
@@ -2128,6 +2128,10 @@ impl Page {
     }
 }
 
+fn activation_verified(visibility: &str, window_focused: bool) -> bool {
+    visibility == "visible" && window_focused
+}
+
 /// Persistent per-user profile directory (aged profiles look human). Override
 /// with `AB_PROFILE`. We deliberately avoid a throwaway temp dir.
 fn default_profile_dir() -> Result<PathBuf> {
@@ -2265,4 +2269,16 @@ async fn discover_ws_url(port: u16) -> Result<String> {
     Err(BrowserError::Discovery(format!(
         "no webSocketDebuggerUrl at {url}"
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::activation_verified;
+
+    #[test]
+    fn activation_requires_visible_and_focused_document() {
+        assert!(activation_verified("visible", true));
+        assert!(!activation_verified("visible", false));
+        assert!(!activation_verified("hidden", true));
+    }
 }

--- a/crates/ab-browser/src/lib.rs
+++ b/crates/ab-browser/src/lib.rs
@@ -332,6 +332,7 @@ impl Browser {
             client: self.client.clone(),
             session_id,
             target_id: target_id.to_string(),
+            #[cfg(target_os = "macos")]
             browser_pid: self.child.as_ref().and_then(Child::id),
             pointer: Arc::new(Mutex::new(None)),
             dialog: Arc::new(Mutex::new((true, None))),
@@ -374,6 +375,7 @@ pub struct Page {
     target_id: String,
     /// Browser process launched by this crate. Used only for a best-effort
     /// macOS foreground fallback; externally connected browsers leave it unset.
+    #[cfg(target_os = "macos")]
     browser_pid: Option<u32>,
     /// Last known pointer position (shared across clones of this page) so mouse
     /// motion is *continuous* — the next move starts where the last one ended,

--- a/crates/ab-browser/src/lib.rs
+++ b/crates/ab-browser/src/lib.rs
@@ -14,6 +14,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use ab_cdp::CdpClient;
+use serde::Serialize;
 use serde_json::{json, Value};
 use tokio::process::{Child, Command};
 use tracing::{debug, info};
@@ -89,6 +90,15 @@ pub enum BrowserError {
 }
 
 pub type Result<T> = std::result::Result<T, BrowserError>;
+
+/// Verified state after bringing a page target to the foreground.
+#[derive(Debug, Clone, Serialize)]
+pub struct PageActivation {
+    pub activated: bool,
+    pub visibility: String,
+    pub window_focused: bool,
+    pub attempts: u8,
+}
 
 #[derive(Debug, Clone)]
 pub struct LaunchOptions {
@@ -322,6 +332,7 @@ impl Browser {
             client: self.client.clone(),
             session_id,
             target_id: target_id.to_string(),
+            browser_pid: self.child.as_ref().and_then(Child::id),
             pointer: Arc::new(Mutex::new(None)),
             dialog: Arc::new(Mutex::new((true, None))),
             routes: Arc::new(Mutex::new(RouteState::default())),
@@ -361,6 +372,9 @@ pub struct Page {
     client: CdpClient,
     session_id: String,
     target_id: String,
+    /// Browser process launched by this crate. Used only for a best-effort
+    /// macOS foreground fallback; externally connected browsers leave it unset.
+    browser_pid: Option<u32>,
     /// Last known pointer position (shared across clones of this page) so mouse
     /// motion is *continuous* — the next move starts where the last one ended,
     /// instead of teleporting to a fresh random origin every click.
@@ -383,6 +397,81 @@ impl Page {
             .await?;
         Ok(())
     }
+
+    /// Bring this target to the foreground and verify the document is visible.
+    ///
+    /// `Target.activateTarget` is the canonical CDP operation. On macOS, when
+    /// this crate launched Chrome and CDP activation alone did not focus the
+    /// window, a best-effort process-level foreground request is made before
+    /// retrying. Externally connected browsers are never guessed by app name.
+    pub async fn activate(&self) -> Result<PageActivation> {
+        let mut visibility = String::from("unknown");
+        let mut window_focused = false;
+
+        for attempts in 1..=3_u8 {
+            self.client
+                .send(
+                    "Target.activateTarget",
+                    json!({ "targetId": self.target_id }),
+                )
+                .await?;
+
+            if attempts > 1 {
+                self.bring_browser_process_to_front().await;
+            }
+            tokio::time::sleep(Duration::from_millis(100 * u64::from(attempts))).await;
+
+            let state = self
+                .evaluate(
+                    "({visibility: document.visibilityState, windowFocused: document.hasFocus()})",
+                )
+                .await?;
+            visibility = state
+                .get("visibility")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown")
+                .to_string();
+            window_focused = state
+                .get("windowFocused")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+
+            if visibility == "visible" && window_focused {
+                return Ok(PageActivation {
+                    activated: true,
+                    visibility,
+                    window_focused,
+                    attempts,
+                });
+            }
+        }
+
+        Ok(PageActivation {
+            activated: visibility == "visible",
+            visibility,
+            window_focused,
+            attempts: 3,
+        })
+    }
+
+    #[cfg(target_os = "macos")]
+    async fn bring_browser_process_to_front(&self) {
+        let Some(pid) = self.browser_pid else {
+            return;
+        };
+        let script = format!(
+            "tell application \"System Events\" to set frontmost of first process whose unix id is {pid} to true"
+        );
+        let _ = Command::new("osascript")
+            .args(["-e", &script])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await;
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    async fn bring_browser_process_to_front(&self) {}
 
     async fn init_stealth(&self) -> Result<()> {
         // Inject before any page script. Does NOT require Runtime.enable.
@@ -889,6 +978,29 @@ impl Page {
             )
             .await?;
         *self.pointer.lock().unwrap() = Some((x, y));
+        Ok(())
+    }
+
+    /// Dispatch a real CDP mouse-wheel event at viewport coordinates.
+    ///
+    /// This intentionally does not use DOM scrolling APIs: sites receive the
+    /// same `mouseWheel` input path as physical trackpad/mouse scrolling.
+    pub async fn wheel(&self, delta_y: f64, x: f64, y: f64) -> Result<()> {
+        self.human_move_to(x, y).await?;
+        self.client
+            .send_on(
+                &self.session_id,
+                "Input.dispatchMouseEvent",
+                json!({
+                    "type": "mouseWheel",
+                    "x": x,
+                    "y": y,
+                    "deltaX": 0.0,
+                    "deltaY": delta_y,
+                }),
+            )
+            .await?;
+        tokio::time::sleep(Duration::from_millis(rand_u64(30, 80))).await;
         Ok(())
     }
 

--- a/crates/ab-mcp/src/main.rs
+++ b/crates/ab-mcp/src/main.rs
@@ -2140,6 +2140,30 @@ mod tests {
             .await;
     }
 
+    #[tokio::test]
+    async fn scoped_page_resolution_blocks_other_owners_for_activation_and_wheel() {
+        let mut state = State::default();
+        state.owners.insert("owner-a".into(), "p1".into());
+        state.owners.insert("owner-b".into(), "p2".into());
+        state.page_owners.insert("p1".into(), "owner-a".into());
+        state.page_owners.insert("p2".into(), "owner-b".into());
+
+        REQUEST_OWNER
+            .scope(Some("owner-a".to_string()), async {
+                assert_eq!(
+                    BrowserServer::resolve_page_id(&state, "owner-a"),
+                    Some("p1".into())
+                );
+                assert_eq!(
+                    BrowserServer::resolve_page_id(&state, "p1"),
+                    Some("p1".into())
+                );
+                assert_eq!(BrowserServer::resolve_page_id(&state, "owner-b"), None);
+                assert_eq!(BrowserServer::resolve_page_id(&state, "p2"), None);
+            })
+            .await;
+    }
+
     #[test]
     fn scoped_release_preserves_durable_page_ownership() {
         let mut state = State::default();

--- a/crates/ab-mcp/src/main.rs
+++ b/crates/ab-mcp/src/main.rs
@@ -499,6 +499,16 @@ fn fail<E: std::fmt::Display>(e: E) -> McpError {
     McpError::internal_error(e.to_string(), None)
 }
 
+fn validate_wheel_input(delta_y: f64, x: f64, y: f64) -> Result<(), &'static str> {
+    if !delta_y.is_finite() || !x.is_finite() || !y.is_finite() {
+        return Err("delta_y, x, and y must be finite numbers");
+    }
+    if x < 0.0 || y < 0.0 {
+        return Err("x and y must be non-negative viewport coordinates");
+    }
+    Ok(())
+}
+
 impl BrowserServer {
     fn new() -> Self {
         Self::with_state(Arc::new(Mutex::new(State::default())))
@@ -921,12 +931,7 @@ impl BrowserServer {
         &self,
         Parameters(a): Parameters<WheelArgs>,
     ) -> Result<CallToolResult, McpError> {
-        if !a.delta_y.is_finite() || !a.x.is_finite() || !a.y.is_finite() {
-            return Err(fail("delta_y, x, and y must be finite numbers"));
-        }
-        if a.x < 0.0 || a.y < 0.0 {
-            return Err(fail("x and y must be non-negative viewport coordinates"));
-        }
+        validate_wheel_input(a.delta_y, a.x, a.y).map_err(fail)?;
 
         let page_id = self.canonical_page_id(&a.page).await?;
         let page = self.page_of(&page_id).await?;
@@ -2114,8 +2119,8 @@ Env equivalents: AB_HTTP, AB_HTTP_CAPABILITY, AB_PROFILE, AB_HEADLESS, AB_STEALT
 mod tests {
     use super::{
         bind_address_is_loopback, constant_time_secret_eq, enforce_scoped_owner, parse_cli_from,
-        parse_connect_port, release_owner_claim, webauthn_options_match_automatic_defaults,
-        BrowserServer, State, REQUEST_OWNER,
+        parse_connect_port, release_owner_claim, validate_wheel_input,
+        webauthn_options_match_automatic_defaults, BrowserServer, State, REQUEST_OWNER,
     };
 
     #[test]
@@ -2212,6 +2217,16 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(names.contains(&"browser_activate_page"));
         assert!(names.contains(&"browser_wheel"));
+    }
+
+    #[test]
+    fn wheel_input_rejects_invalid_coordinates_and_non_finite_numbers() {
+        assert!(validate_wheel_input(700.0, 650.0, 500.0).is_ok());
+        assert!(validate_wheel_input(-700.0, 650.0, 500.0).is_ok());
+        assert!(validate_wheel_input(700.0, -1.0, 500.0).is_err());
+        assert!(validate_wheel_input(700.0, 650.0, -1.0).is_err());
+        assert!(validate_wheel_input(f64::INFINITY, 650.0, 500.0).is_err());
+        assert!(validate_wheel_input(700.0, f64::NAN, 500.0).is_err());
     }
 }
 

--- a/crates/ab-mcp/src/main.rs
+++ b/crates/ab-mcp/src/main.rs
@@ -26,6 +26,8 @@ const INSTRUCTIONS: &str = r#"browser-rs — a real Chrome driven over CDP, no b
 Loop: browser_navigate -> browser_snapshot -> act (click/type) -> re-snapshot to verify.
 - snapshot renders the page as an accessibility tree; interactive nodes carry [ref=eN] handles.
 - act on them by ref with browser_click / browser_type / browser_press_key.
+- browser_activate_page explicitly foregrounds a tab and verifies visibility.
+- browser_wheel sends native CDP mouse-wheel input for lazy-loaded feeds.
 - refs go stale when the page changes — re-snapshot before reusing them.
 - browser_evaluate runs one-shot JS; browser_take_screenshot saves a PNG.
 Stealth: default paths avoid Runtime.enable; browser_console_messages opts in on first use."#;
@@ -163,6 +165,18 @@ struct FindArgs {
 struct PageArg {
     /// Page id (e.g. "p1") or owner alias from browser_claim_page.
     page: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct WheelArgs {
+    /// Page id (e.g. "p1") or owner alias from browser_claim_page.
+    page: String,
+    /// Vertical wheel delta in CSS pixels. Positive scrolls down.
+    delta_y: f64,
+    /// Viewport x coordinate where the wheel event is dispatched.
+    x: f64,
+    /// Viewport y coordinate where the wheel event is dispatched.
+    y: f64,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -867,6 +881,25 @@ impl BrowserServer {
         Ok(ok(format!("page {}\n\n{}", a.page, snap.text)))
     }
 
+    /// Activate a page target and verify foreground/visibility state.
+    #[tool(description = "Bring a page tab to the foreground and verify document visibility/focus")]
+    async fn browser_activate_page(
+        &self,
+        Parameters(a): Parameters<PageArg>,
+    ) -> Result<CallToolResult, McpError> {
+        let page_id = self.canonical_page_id(&a.page).await?;
+        let page = self.page_of(&page_id).await?;
+        let activation = page.activate().await.map_err(fail)?;
+        Ok(ok(serde_json::to_string_pretty(&serde_json::json!({
+            "page": page_id,
+            "activated": activation.activated,
+            "visibility": activation.visibility,
+            "window_focused": activation.window_focused,
+            "attempts": activation.attempts,
+        }))
+        .unwrap_or_else(|_| "{}".into())))
+    }
+
     /// Click an element by its snapshot ref, then report what changed.
     #[tool(description = "Click an element by ref (synthesized mouse click); returns settle-diff")]
     async fn browser_click(
@@ -878,6 +911,36 @@ impl BrowserServer {
         page.click(backend).await.map_err(fail)?;
         let diff = self.settle_diff(&a.page, &page).await?;
         Ok(ok(format!("clicked on {}\n\n{}", a.page, diff)))
+    }
+
+    /// Send a native CDP mouse-wheel event at viewport coordinates.
+    #[tool(
+        description = "Scroll with a real CDP mouseWheel event at viewport coordinates; returns settle-diff"
+    )]
+    async fn browser_wheel(
+        &self,
+        Parameters(a): Parameters<WheelArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        if !a.delta_y.is_finite() || !a.x.is_finite() || !a.y.is_finite() {
+            return Err(fail("delta_y, x, and y must be finite numbers"));
+        }
+        if a.x < 0.0 || a.y < 0.0 {
+            return Err(fail("x and y must be non-negative viewport coordinates"));
+        }
+
+        let page_id = self.canonical_page_id(&a.page).await?;
+        let page = self.page_of(&page_id).await?;
+        page.wheel(a.delta_y, a.x, a.y).await.map_err(fail)?;
+        let diff = self.settle_diff(&page_id, &page).await?;
+        Ok(ok(serde_json::to_string_pretty(&serde_json::json!({
+            "page": page_id,
+            "dispatched": true,
+            "delta_y": a.delta_y,
+            "x": a.x,
+            "y": a.y,
+            "diff": diff,
+        }))
+        .unwrap_or_else(|_| "{}".into())))
     }
 
     /// Type text into an element by ref (optionally clearing it first).
@@ -2051,8 +2114,8 @@ Env equivalents: AB_HTTP, AB_HTTP_CAPABILITY, AB_PROFILE, AB_HEADLESS, AB_STEALT
 mod tests {
     use super::{
         bind_address_is_loopback, constant_time_secret_eq, enforce_scoped_owner, parse_cli_from,
-        parse_connect_port, release_owner_claim, webauthn_options_match_automatic_defaults, State,
-        REQUEST_OWNER,
+        parse_connect_port, release_owner_claim, webauthn_options_match_automatic_defaults,
+        BrowserServer, State, REQUEST_OWNER,
     };
 
     #[test]
@@ -2138,6 +2201,17 @@ mod tests {
         assert!(!webauthn_options_match_automatic_defaults(
             "internal", true, false
         ));
+    }
+
+    #[test]
+    fn foreground_and_wheel_tools_are_publicly_registered() {
+        let tools = BrowserServer::new().tool_router.list_all();
+        let names = tools
+            .iter()
+            .map(|tool| tool.name.as_ref())
+            .collect::<Vec<_>>();
+        assert!(names.contains(&"browser_activate_page"));
+        assert!(names.contains(&"browser_wheel"));
     }
 }
 

--- a/scripts/mcp-smoke.mjs
+++ b/scripts/mcp-smoke.mjs
@@ -43,7 +43,14 @@ console.log("initialize:", init.result?.serverInfo?.name, "| tools cap:", !!init
 notify("notifications/initialized", {});
 
 const tools = await send("tools/list", {});
-console.log("tools:", tools.result.tools.map((t) => t.name).join(", "));
+const toolNames = tools.result.tools.map((t) => t.name);
+console.log("tools:", toolNames.join(", "));
+for (const required of ["browser_activate_page", "browser_wheel"]) {
+  if (!toolNames.includes(required)) {
+    child.kill();
+    throw new Error(`missing tool: ${required}`);
+  }
+}
 
 const nav = await send("tools/call", {
   name: "browser_navigate",
@@ -52,6 +59,34 @@ const nav = await send("tools/call", {
 const text = nav.result?.content?.[0]?.text || JSON.stringify(nav.error);
 console.log("--- browser_navigate result ---");
 console.log(text.split("\n").slice(0, 12).join("\n"));
+
+const activated = await send("tools/call", {
+  name: "browser_activate_page",
+  arguments: { page: "p1" },
+});
+console.log("--- browser_activate_page ---");
+console.log(activated.result?.content?.[0]?.text || JSON.stringify(activated.error));
+
+await send("tools/call", {
+  name: "browser_evaluate",
+  arguments: { page: "p1", expression: "document.body.style.minHeight='3000px'; 0" },
+});
+const wheel = await send("tools/call", {
+  name: "browser_wheel",
+  arguments: { page: "p1", delta_y: 300, x: 640, y: 400 },
+});
+console.log("--- browser_wheel ---");
+console.log(wheel.result?.content?.[0]?.text || JSON.stringify(wheel.error));
+const scrollY = await send("tools/call", {
+  name: "browser_evaluate",
+  arguments: { page: "p1", expression: "scrollY" },
+});
+const scrollValue = Number(scrollY.result?.content?.[0]?.text);
+if (!(scrollValue > 0)) {
+  child.kill();
+  throw new Error(`mouseWheel did not move the page: scrollY=${scrollValue}`);
+}
+console.log("scrollY after mouseWheel:", scrollValue);
 
 // act: click the first ref, then re-snapshot to verify navigation.
 const click = await send("tools/call", {


### PR DESCRIPTION
## Summary
- Add CDP page activation with visibility/focus verification.
- Add native CDP mouse-wheel scrolling for viewport coordinates.
- Add release tag-to-package-version verification.

## Review findings/fixes
- Fixed activation reporting success when a page was visible but `document.hasFocus()` was false.
- Added owner-scoped page-resolution coverage so activation and wheel cannot address another owner's page.
- Block release tags that do not match the `ab-mcp` package version.

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build -p ab-mcp`
- `cargo build --release -p ab-mcp`
- `git diff --check`
- `node scripts/mcp-smoke.mjs target/debug/browser-rs` (headful Chrome: focused activation and native wheel `scrollY=300`)