### PR TITLE
v0.1.23: add trusted iframe typing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ab-browser"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "ab-cdp",
  "anyhow",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "ab-cdp"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "futures-util",
  "serde",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "ab-mcp"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "ab-browser",
  "ab-cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/ab-cdp", "crates/ab-browser", "crates/ab-mcp"]
 
 [workspace.package]
-version = "0.1.22"
+version = "0.1.23"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,7 +22,7 @@ browser-rs --help
 
 ```bash
 # Pin a specific version
-curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | AB_VERSION=v0.1.16 sh
+curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | AB_VERSION=v0.1.23 sh
 
 # Choose the install directory
 AB_BIN_DIR=~/bin curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | sh

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ browser-rs --help
 To pin this release instead of following `latest`:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | AB_VERSION=v0.1.22 sh
+curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | AB_VERSION=v0.1.23 sh
 ```
 
 **2. Run** — use stdio for a client that launches the server:
@@ -90,7 +90,15 @@ cargo install --git https://github.com/maestrojeong/browser-rs-mcp ab-mcp
 Set `AB_CHROME` if Chrome is not in a standard location.
 
 <details>
-<summary><strong>What's new (v0.1.14 - v0.1.22)</strong></summary>
+<summary><strong>What's new (v0.1.14 - v0.1.23)</strong></summary>
+
+**v0.1.23 — trusted iframe typing.** The new `browser_iframe_type` tool
+focuses inputs inside same-origin, cross-origin, and out-of-process iframes,
+then dispatches browser-generated CDP keyboard input on the innermost frame's
+own session. This supports React-controlled and masked inputs that reject
+`element.value` assignment plus synthetic DOM events. It shares
+`browser_type`'s humanized short-text typing, atomic long-text insertion,
+`clear`, blocking-by-default behavior, and `browser_cancel_typing` support.
 
 **v0.1.22 — exact pointer capabilities.** Snapshot refs are unique capabilities
 bound to the page target and main-document loader, so navigation and later
@@ -346,11 +354,11 @@ whole section — it only activates when a host explicitly configures it.
 
 ## Tools
 
-MCP exposes 67 `browser_*` tools:
+MCP exposes 68 `browser_*` tools:
 
 **Navigation and inspection:** `browser_navigate` · `browser_new_page` · `browser_snapshot` · `browser_activate_page` · `browser_read` · `browser_get_visible_html` · `browser_get_visible_text` · `browser_find` · `browser_take_screenshot` · `browser_save_pdf` · `browser_pages` · `browser_tabs` · `browser_switch_page` · `browser_profile` · `browser_status`
 
-**Interaction:** `browser_click` · `browser_pointer` · `browser_wheel` · `browser_type` · `browser_cancel_typing` · `browser_press_key` · `browser_hover` · `browser_select_option` · `browser_fill_form` · `browser_drag` · `browser_file_upload` · `browser_navigate_back` · `browser_wait_for` · `browser_resize` · `browser_evaluate` · `browser_run_code_unsafe` · `browser_iframe_click` · `browser_iframe_fill` · `browser_iframe_read` · `browser_close_page` · `browser_close`
+**Interaction:** `browser_click` · `browser_pointer` · `browser_wheel` · `browser_type` · `browser_cancel_typing` · `browser_press_key` · `browser_hover` · `browser_select_option` · `browser_fill_form` · `browser_drag` · `browser_file_upload` · `browser_navigate_back` · `browser_wait_for` · `browser_resize` · `browser_evaluate` · `browser_run_code_unsafe` · `browser_iframe_click` · `browser_iframe_fill` · `browser_iframe_type` · `browser_iframe_read` · `browser_close_page` · `browser_close`
 
 Use `browser_activate_page({ "page": "p5" })` before automating a background
 tab whose site throttles lazy loading. It calls CDP `Target.activateTarget`,
@@ -364,6 +372,9 @@ events have `isTrusted == false`; they are never an automatic fallback from
 trusted CDP input.
 `browser_type` keeps human-like key events for text under 30 characters and
 uses one atomic CDP `Input.insertText` command for longer input.
+`browser_iframe_type` applies the same input behavior after focusing the target
+inside a nested iframe chain and routes OOPIF input through that frame's CDP
+session; use it instead of `browser_iframe_fill` for controlled or masked inputs.
 `browser_cancel_typing` stops active per-character typing started with
 `wait: false`; text already entered remains, while atomic long-text insertion
 normally finishes before cancellation.

--- a/crates/ab-browser/src/lib.rs
+++ b/crates/ab-browser/src/lib.rs
@@ -388,6 +388,7 @@ pub enum ReadMode {
 enum FrameAction<'a> {
     Click,
     Fill(&'a str),
+    Focus { clear: bool },
     Read(ReadMode),
 }
 
@@ -447,6 +448,14 @@ fn build_descend_js(chain: &[&str], selector: &str, action: &FrameAction<'_>) ->
             "el.focus(); el.value={v}; el.dispatchEvent(new Event('input',{{bubbles:true}})); el.dispatchEvent(new Event('change',{{bubbles:true}})); return {{ ok: true }};",
             v = serde_json::to_string(value).unwrap_or_else(|_| "\"\"".into()),
         ),
+        FrameAction::Focus { clear } => {
+            let select_js = if *clear {
+                " if (typeof el.select === 'function') el.select(); else if (typeof el.setSelectionRange === 'function') el.setSelectionRange(0, (el.value || '').length);"
+            } else {
+                ""
+            };
+            format!("el.focus();{select_js} return {{ ok: true }};")
+        }
         FrameAction::Read(ReadMode::Html) => "return { ok: true, value: el.outerHTML };".to_string(),
         FrameAction::Read(ReadMode::Text) => {
             "return { ok: true, value: (el.innerText !== undefined ? el.innerText : (el.textContent || '')) };"
@@ -1301,26 +1310,39 @@ impl Page {
                     )
                     .await?;
             }
+        }
+
+        self.dispatch_text_cancellable(&self.session_id, text, clear, cancel)
+            .await
+    }
+
+    /// Dispatch text to the element currently focused in `session_id`.
+    /// Keeping the session explicit lets iframe typing target an OOPIF's own
+    /// renderer session instead of always falling back to the top-level page.
+    async fn dispatch_text_cancellable(
+        &self,
+        session_id: &str,
+        text: &str,
+        clear: bool,
+        cancel: &CancellationToken,
+    ) -> Result<()> {
+        if clear {
             // Delete the selection so typed keys replace it.
             for kind in ["keyDown", "keyUp"] {
                 self.client
                     .send_on(
-                        &self.session_id,
+                        session_id,
                         "Input.dispatchKeyEvent",
                         json!({ "type": kind, "key": "Delete", "code": "Delete", "windowsVirtualKeyCode": 46 }),
-                )
-                .await?;
+                    )
+                    .await?;
             }
         }
 
         ensure_typing_active(cancel)?;
         if uses_insert_text(text) {
             self.client
-                .send_on(
-                    &self.session_id,
-                    "Input.insertText",
-                    json!({ "text": text }),
-                )
+                .send_on(session_id, "Input.insertText", json!({ "text": text }))
                 .await?;
             return Ok(());
         }
@@ -1329,7 +1351,7 @@ impl Page {
         for ch in text.chars() {
             if cancel.is_cancelled() {
                 if shift_held {
-                    self.release_shift().await?;
+                    self.release_shift_on(session_id).await?;
                 }
                 return Err(BrowserError::TypingCancelled);
             }
@@ -1341,24 +1363,24 @@ impl Page {
             if need_shift && !shift_held {
                 self.client
                     .send_on(
-                        &self.session_id,
+                        session_id,
                         "Input.dispatchKeyEvent",
                         json!({ "type": "keyDown", "key": "Shift", "code": "ShiftLeft", "modifiers": 8 }),
                     )
                     .await?;
                 shift_held = true;
                 if typing_delay(cancel, rand_u64(15, 45)).await.is_err() {
-                    self.release_shift().await?;
+                    self.release_shift_on(session_id).await?;
                     return Err(BrowserError::TypingCancelled);
                 }
             } else if !need_shift && shift_held {
-                self.release_shift().await?;
+                self.release_shift_on(session_id).await?;
                 shift_held = false;
             }
             let modifiers = if need_shift { 8 } else { 0 };
             self.client
                 .send_on(
-                    &self.session_id,
+                    session_id,
                     "Input.dispatchKeyEvent",
                     json!({ "type": "keyDown", "text": s, "key": s, "unmodifiedText": s, "modifiers": modifiers }),
                 )
@@ -1367,14 +1389,14 @@ impl Page {
             let cancelled = typing_delay(cancel, rand_u64(20, 90)).await.is_err();
             self.client
                 .send_on(
-                    &self.session_id,
+                    session_id,
                     "Input.dispatchKeyEvent",
                     json!({ "type": "keyUp", "key": s, "modifiers": modifiers }),
                 )
                 .await?;
             if cancelled {
                 if shift_held {
-                    self.release_shift().await?;
+                    self.release_shift_on(session_id).await?;
                 }
                 return Err(BrowserError::TypingCancelled);
             }
@@ -1391,21 +1413,21 @@ impl Page {
             };
             if typing_delay(cancel, gap).await.is_err() {
                 if shift_held {
-                    self.release_shift().await?;
+                    self.release_shift_on(session_id).await?;
                 }
                 return Err(BrowserError::TypingCancelled);
             }
         }
         if shift_held {
-            self.release_shift().await?;
+            self.release_shift_on(session_id).await?;
         }
         Ok(())
     }
 
-    async fn release_shift(&self) -> Result<()> {
+    async fn release_shift_on(&self, session_id: &str) -> Result<()> {
         self.client
             .send_on(
-                &self.session_id,
+                session_id,
                 "Input.dispatchKeyEvent",
                 json!({ "type": "keyUp", "key": "Shift", "code": "ShiftLeft" }),
             )
@@ -1473,6 +1495,26 @@ impl Page {
         Ok(())
     }
 
+    /// Focus an input inside a same-origin, cross-origin, or OOPIF iframe and
+    /// type through CDP's Input domain. Unlike `iframe_fill`, this does not
+    /// assign `element.value` or synthesize DOM events, so controlled inputs
+    /// receive the browser-generated keyboard/input event sequence.
+    pub async fn iframe_type_text_cancellable(
+        &self,
+        frame_selector: &str,
+        selector: &str,
+        text: &str,
+        clear: bool,
+        cancel: &CancellationToken,
+    ) -> Result<()> {
+        let chain = require_frame_chain(frame_selector)?;
+        let (_, session_id) = self
+            .descend_and_act_with_session(&chain, selector, &FrameAction::Focus { clear })
+            .await?;
+        self.dispatch_text_cancellable(&session_id, text, clear, cancel)
+            .await
+    }
+
     /// Read an element's `outerHTML` (`ReadMode::Html`) or rendered text
     /// (`ReadMode::Text`) from inside an iframe. `frame_selector` may be a
     /// single CSS selector or a `>>`-separated chain for nested iframes, and
@@ -1516,6 +1558,20 @@ impl Page {
         selector: &str,
         action: &FrameAction<'_>,
     ) -> Result<Value> {
+        self.descend_and_act_with_session(chain, selector, action)
+            .await
+            .map(|(value, _)| value)
+    }
+
+    /// Variant of `descend_and_act` that also returns the CDP session owning
+    /// the innermost frame. Keyboard input must be dispatched on that session
+    /// when Site Isolation places the target frame in an OOPIF renderer.
+    async fn descend_and_act_with_session(
+        &self,
+        chain: &[&str],
+        selector: &str,
+        action: &FrameAction<'_>,
+    ) -> Result<(Value, String)> {
         let mut context: Option<FrameExecutionContext> = None;
         let mut remaining: Vec<&str> = chain.to_vec();
         // Bound the loop: at most one CDP hop per chain element, plus one.
@@ -1526,7 +1582,11 @@ impl Page {
                 Some(ctx) => self.eval_with_context(&js, ctx).await?,
             };
             if result.get("ok").and_then(Value::as_bool) == Some(true) {
-                return Ok(result);
+                let session_id = context
+                    .as_ref()
+                    .map(|ctx| ctx.session_id.clone())
+                    .unwrap_or_else(|| self.session_id.clone());
+                return Ok((result, session_id));
             }
             let index = result.get("index").and_then(Value::as_u64).unwrap_or(0) as usize;
             let src = result
@@ -2847,6 +2907,27 @@ mod tests {
         assert!(js.contains(r#"el.value="hello \"world\"";"#));
         assert!(js.contains("dispatchEvent(new Event('input'"));
         assert!(js.contains("dispatchEvent(new Event('change'"));
+    }
+
+    #[test]
+    fn descend_js_focus_selects_only_when_clear_is_requested() {
+        let append = build_descend_js(
+            &["iframe#f"],
+            "input#phone",
+            &FrameAction::Focus { clear: false },
+        );
+        assert!(append.contains("el.focus();"));
+        assert!(!append.contains("el.select()"));
+
+        let replace = build_descend_js(
+            &["iframe#f"],
+            "input#phone",
+            &FrameAction::Focus { clear: true },
+        );
+        assert!(replace.contains("el.focus();"));
+        assert!(replace.contains("el.select()"));
+        assert!(!replace.contains("el.value="));
+        assert!(!replace.contains("dispatchEvent"));
     }
 
     #[test]

--- a/crates/ab-mcp/src/main.rs
+++ b/crates/ab-mcp/src/main.rs
@@ -638,6 +638,25 @@ struct IframeFillArgs {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+struct IframeTypeArgs {
+    page: String,
+    /// CSS selector for the <iframe> element, or a " >> "-separated chain
+    /// for nested iframes. Same-origin and cross-origin frames are supported.
+    frame_selector: String,
+    /// CSS selector for the input inside the innermost iframe.
+    selector: String,
+    /// Text to type through trusted CDP keyboard input.
+    text: String,
+    /// Replace existing content instead of appending.
+    #[serde(default)]
+    clear: bool,
+    /// Wait for typing to finish and return the resulting page diff. Set false
+    /// only when the typing must remain cancellable by browser_cancel_typing.
+    #[serde(default = "default_true")]
+    wait: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 struct IframeReadArgs {
     page: String,
     /// CSS selector for the <iframe> element, or a " >> "-separated chain
@@ -2215,6 +2234,51 @@ impl BrowserServer {
         Ok(ok(format!("iframe-filled on {}", a.page)))
     }
 
+    /// Type into an input inside an iframe using trusted CDP keyboard input.
+    #[tool(
+        description = "Type text into an element inside a same-origin or cross-origin iframe using trusted CDP keyboard input; chain nested iframes in frame_selector with ' >> '; waits by default and supports browser_cancel_typing when wait=false"
+    )]
+    async fn browser_iframe_type(
+        &self,
+        Parameters(a): Parameters<IframeTypeArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let (page_id, page, cancel) = self.begin_typing(&a.page).await?;
+        if a.wait {
+            let result = page
+                .iframe_type_text_cancellable(
+                    &a.frame_selector,
+                    &a.selector,
+                    &a.text,
+                    a.clear,
+                    &cancel,
+                )
+                .await;
+            self.finish_typing(&page_id, &cancel).await;
+            result.map_err(fail)?;
+            let diff = self.settle_diff(&page_id, &page).await?;
+            return Ok(ok(format!("iframe-typed into {page_id}\n\n{diff}")));
+        }
+
+        let server = self.clone();
+        let task_page_id = page_id.clone();
+        tokio::spawn(async move {
+            let result = page
+                .iframe_type_text_cancellable(
+                    &a.frame_selector,
+                    &a.selector,
+                    &a.text,
+                    a.clear,
+                    &cancel,
+                )
+                .await;
+            server.finish_typing(&task_page_id, &cancel).await;
+            if let Err(e) = result {
+                tracing::warn!("background iframe typing on {task_page_id} failed: {e}");
+            }
+        });
+        Ok(ok(format!("iframe typing started on {page_id}")))
+    }
+
     /// Read HTML or text from inside an iframe (same-origin or cross-origin,
     /// including nested chains via " >> "). Use this to inspect content
     /// hidden behind a cross-origin iframe that `browser_get_visible_html`
@@ -2700,7 +2764,7 @@ mod tests {
         bind_address_is_loopback, constant_time_secret_eq, enforce_scoped_owner,
         force_scoped_owner_argument, parse_allowed_tools, parse_cli_from, parse_connect_port,
         release_owner_claim, snapshot_diff, truncate_text, validate_wheel_input,
-        webauthn_options_match_automatic_defaults, BrowserServer, State, TypeArgs,
+        webauthn_options_match_automatic_defaults, BrowserServer, IframeTypeArgs, State, TypeArgs,
         DEFAULT_MAX_OUTPUT_LIMIT, REQUEST_OWNER,
     };
     use rmcp::model::CallToolRequestParams;
@@ -2871,7 +2935,7 @@ mod tests {
     }
 
     #[test]
-    fn foreground_pointer_wheel_and_cancel_typing_tools_are_publicly_registered() {
+    fn foreground_pointer_wheel_and_typing_tools_are_publicly_registered() {
         let tools = BrowserServer::new().tool_router.list_all();
         let names = tools
             .iter()
@@ -2881,6 +2945,7 @@ mod tests {
         assert!(names.contains(&"browser_pointer"));
         assert!(names.contains(&"browser_wheel"));
         assert!(names.contains(&"browser_cancel_typing"));
+        assert!(names.contains(&"browser_iframe_type"));
     }
 
     #[test]
@@ -2901,6 +2966,15 @@ mod tests {
         }))
         .unwrap();
         assert!(!background.wait);
+
+        let iframe: IframeTypeArgs = serde_json::from_value(serde_json::json!({
+            "page": "p1",
+            "frame_selector": "iframe#outer >> iframe#inner",
+            "selector": "#phone",
+            "text": "01012345678"
+        }))
+        .unwrap();
+        assert!(iframe.wait);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add browser_iframe_type for nested same-origin, cross-origin, and OOPIF inputs
- route CDP keyboard events through the innermost frame session
- preserve clear, wait, cancellation, and humanized typing behavior
- bump workspace and install documentation to 0.1.23

## Verification
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- live smoke: DOM iframe fill reverted; trusted iframe typing retained masked controlled state after blur