### PR TITLE
v0.2.0: trusted-only browser defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ab-browser"
-version = "0.1.23"
+version = "0.2.0"
 dependencies = [
  "ab-cdp",
  "anyhow",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "ab-cdp"
-version = "0.1.23"
+version = "0.2.0"
 dependencies = [
  "futures-util",
  "serde",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "ab-mcp"
-version = "0.1.23"
+version = "0.2.0"
 dependencies = [
  "ab-browser",
  "ab-cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/ab-cdp", "crates/ab-browser", "crates/ab-mcp"]
 
 [workspace.package]
-version = "0.1.23"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,7 +22,7 @@ browser-rs --help
 
 ```bash
 # Pin a specific version
-curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | AB_VERSION=v0.1.23 sh
+curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | AB_VERSION=v0.2.0 sh
 
 # Choose the install directory
 AB_BIN_DIR=~/bin curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | sh
@@ -64,9 +64,12 @@ browser-rs --port 9321         # HTTP MCP: http://127.0.0.1:9321/mcp (streamable
 
 Common flags: `--host <host>`, `--user-data-dir <path>` (persistent profile),
 `--headless` / `--headed`, `--connect <port|url>` (attach to your own Chrome),
-`--stealth` (headless JS patch layer). Each has an env equivalent (`AB_HTTP`,
-`AB_PROFILE`, `AB_HEADLESS`, `AB_CONNECT`, `AB_STEALTH`, `AB_CHROME`). In HTTP
-mode, `AB_HTTP_CAPABILITY` optionally requires a matching
+`--stealth` (headless JS patch layer), and `--allow-detectable-tools`
+(explicitly enable main-world JS and Runtime console
+capture; blocked by default). Each has an env equivalent (`AB_HTTP`,
+`AB_PROFILE`, `AB_HEADLESS`, `AB_CONNECT`, `AB_STEALTH`, `AB_CHROME`,
+`AB_ALLOW_DETECTABLE_TOOLS`). In HTTP mode, `AB_HTTP_CAPABILITY` optionally
+requires a matching
 `X-Browser-Capability` header on every endpoint and is required for non-loopback
 binds.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ browser-rs --help
 To pin this release instead of following `latest`:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | AB_VERSION=v0.1.23 sh
+curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | AB_VERSION=v0.2.0 sh
 ```
 
 **2. Run** — use stdio for a client that launches the server:
@@ -90,7 +90,19 @@ cargo install --git https://github.com/maestrojeong/browser-rs-mcp ab-mcp
 Set `AB_CHROME` if Chrome is not in a standard location.
 
 <details>
-<summary><strong>What's new (v0.1.14 - v0.1.23)</strong></summary>
+<summary><strong>What's new (v0.1.14 - v0.2.0)</strong></summary>
+
+**v0.2.0 — trusted-only interaction defaults.** Synthetic pointer delivery and
+`browser_iframe_fill` have been removed. `browser_iframe_click` now resolves
+same-origin, cross-origin, and OOPIF target boxes before dispatching trusted CDP
+mouse input; `browser_select_option` uses trusted native-select type-ahead
+keyboard events instead of assigning `select.value`. Strict mode is now the
+default: console capture is hidden and `browser_evaluate(main_world=true)` is
+rejected unless the server starts with `--allow-detectable-tools`. Virtual
+WebAuthn authenticators are no longer installed automatically; call
+`browser_webauthn` explicitly before a passkey challenge when needed.
+JavaScript dialog handling likewise starts only after an explicit
+`browser_handle_dialog` call.
 
 **v0.1.23 — trusted iframe typing.** The new `browser_iframe_type` tool
 focuses inputs inside same-origin, cross-origin, and out-of-process iframes,
@@ -352,13 +364,25 @@ if you want the redaction broker (see [CLI and environment](#cli-and-environment
 for full per-variable semantics). Standalone/self-hosted users can ignore this
 whole section — it only activates when a host explicitly configures it.
 
+## Strict anti-detection mode
+
+Strict mode is the default. It hides `browser_console_messages`, which enables
+the observable Runtime domain, and rejects `browser_evaluate` with
+`main_world: true`. Every public interaction tool uses trusted CDP input;
+synthetic DOM pointer/fill routes are not part of the v0.2 API.
+
+Start with `--allow-detectable-tools` (or set
+`AB_ALLOW_DETECTABLE_TOOLS=1`) only for an explicit debugging or compatibility
+session. `AB_ALLOWED_TOOLS` is still applied as an additional fail-closed
+allowlist and cannot override strict mode.
+
 ## Tools
 
-MCP exposes 68 `browser_*` tools:
+MCP implements 67 `browser_*` tools; strict mode advertises 66 by default:
 
 **Navigation and inspection:** `browser_navigate` · `browser_new_page` · `browser_snapshot` · `browser_activate_page` · `browser_read` · `browser_get_visible_html` · `browser_get_visible_text` · `browser_find` · `browser_take_screenshot` · `browser_save_pdf` · `browser_pages` · `browser_tabs` · `browser_switch_page` · `browser_profile` · `browser_status`
 
-**Interaction:** `browser_click` · `browser_pointer` · `browser_wheel` · `browser_type` · `browser_cancel_typing` · `browser_press_key` · `browser_hover` · `browser_select_option` · `browser_fill_form` · `browser_drag` · `browser_file_upload` · `browser_navigate_back` · `browser_wait_for` · `browser_resize` · `browser_evaluate` · `browser_run_code_unsafe` · `browser_iframe_click` · `browser_iframe_fill` · `browser_iframe_type` · `browser_iframe_read` · `browser_close_page` · `browser_close`
+**Interaction:** `browser_click` · `browser_pointer` · `browser_wheel` · `browser_type` · `browser_cancel_typing` · `browser_press_key` · `browser_hover` · `browser_select_option` · `browser_fill_form` · `browser_drag` · `browser_file_upload` · `browser_navigate_back` · `browser_wait_for` · `browser_resize` · `browser_evaluate` · `browser_run_code_unsafe` · `browser_iframe_click` · `browser_iframe_type` · `browser_iframe_read` · `browser_close_page` · `browser_close`
 
 Use `browser_activate_page({ "page": "p5" })` before automating a background
 tab whose site throttles lazy loading. It calls CDP `Target.activateTarget`,
@@ -366,24 +390,27 @@ retries visibility/focus verification, and uses a process-specific macOS
 foreground fallback when browser-rs launched Chrome itself. Use
 `browser_wheel({ "page": "p5", "delta_y": 700, "x": 650, "y": 500 })` for a
 real CDP `mouseWheel` event instead of DOM `window.scrollBy()`.
-Use `browser_pointer` for right-click/double-click and for an explicit
-`input_route: "dom_event"` background compatibility path. Constructed DOM
-events have `isTrusted == false`; they are never an automatic fallback from
-trusted CDP input.
-`browser_type` keeps human-like key events for text under 30 characters and
-uses one atomic CDP `Input.insertText` command for longer input.
+Use `browser_pointer` for trusted right-click, double-click, scroll, and drag;
+v0.2 has no synthetic `input_route`.
+`browser_type` uses humanized per-character keys for short text and trusted
+atomic insertion for paste/IME-like text of 30 characters or more.
 `browser_iframe_type` applies the same input behavior after focusing the target
 inside a nested iframe chain and routes OOPIF input through that frame's CDP
-session; use it instead of `browser_iframe_fill` for controlled or masked inputs.
-`browser_cancel_typing` stops active per-character typing started with
-`wait: false`; text already entered remains, while atomic long-text insertion
-normally finishes before cancellation.
+session. `browser_iframe_click` similarly uses trusted pointer input, while
+`browser_select_option` performs native select type-ahead with trusted keys.
+`browser_cancel_typing` stops active typing started with `wait: false`; text
+already entered remains.
 
 **Network and requests:** `browser_network_requests` · `browser_route_block` · `browser_route_mock` · `browser_route_clear` · `browser_network_state_set` · `browser_api_request`
 
 **Cookies and storage:** `browser_cookie_list` · `browser_cookie_get` · `browser_cookie_set` · `browser_cookie_delete` · `browser_cookie_clear` · `browser_localstorage_list` · `browser_localstorage_get` · `browser_localstorage_set` · `browser_localstorage_delete` · `browser_localstorage_clear` · `browser_sessionstorage_list` · `browser_sessionstorage_get` · `browser_sessionstorage_set` · `browser_sessionstorage_delete` · `browser_sessionstorage_clear` · `browser_storage_save` · `browser_storage_load`
 
 **Diagnostics and page utilities:** `browser_console_messages` · `browser_fingerprint_check` · `browser_handle_dialog` · `browser_highlight` · `browser_hide_highlight` · `browser_webauthn` · `browser_claim_page` · `browser_release_page`
+
+`browser_webauthn` is opt-in and affects only the selected page. Ordinary
+navigation leaves Chrome's native WebAuthn/passkey behavior untouched.
+`browser_handle_dialog` is also opt-in; without it, alert/confirm/prompt
+dialogs retain native Chrome behavior.
 
 ## CLI and environment
 
@@ -397,12 +424,14 @@ browser-rs --port 9321 [options]    # HTTP MCP transport
   --headed                 Run headful (default)
   --connect <port|url>     Attach to an existing Chrome
   --stealth                Enable the JS fallback layer
+  --allow-detectable-tools Opt in to observable debugging paths
 ```
 
 `--port` enables HTTP mode; without it, the server uses stdio. The equivalent
 environment variables are `AB_HTTP`, `AB_PROFILE`, `AB_HEADLESS`, `AB_CONNECT`,
-`AB_STEALTH`, and `AB_CHROME`. `AB_HTTP_CAPABILITY` protects HTTP/SSE requests
-with `X-Browser-Capability` and is required for non-loopback binds.
+`AB_STEALTH`, `AB_CHROME`, and `AB_ALLOW_DETECTABLE_TOOLS`.
+`AB_HTTP_CAPABILITY` protects HTTP/SSE requests with `X-Browser-Capability`
+and is required for non-loopback binds.
 
 Managed hosts (see [Managed mode](#managed-mode-secure-multi-tenant-hosting)
 above) can set:
@@ -413,6 +442,7 @@ above) can set:
 | `AB_HTTP_CAPABILITY=<random-root>` | Root secret the host derives per-owner tokens from |
 | `AB_SPAWN_NONCE=<random-nonce>` | Reported on `/health` so the host can confirm which process instance is live |
 | `AB_ALLOWED_TOOLS=<a,b,c>` | Fail-closed allowlist of callable/visible `browser_*` tool names |
+| `AB_ALLOW_DETECTABLE_TOOLS=1` | Opt in to main-world JS and Runtime-enabled console capture |
 | `AB_SECRET_BROKER_SOCKET`, `AB_SECRET_BROKER_TOKEN` | Unix-socket broker that injects secrets into tool input and redacts them from tool output |
 | `AB_MAX_OUTPUT_LIMIT=<bytes>` | Absolute ceiling any caller's `maxLength`/`maxBytes` is clamped to (default 5,000,000 — already far above the 100k/200k tool defaults, so it only matters if a host needs a different bound) |
 

--- a/bench/rebrowser.mjs
+++ b/bench/rebrowser.mjs
@@ -5,7 +5,8 @@
 import { spawn } from "node:child_process";
 
 const bin = process.argv[2] || "target/release/browser-rs";
-const c = spawn(bin, [], { stdio: ["pipe", "pipe", "ignore"] });
+// Opt in only because the harness reads the detector's main-world result table.
+const c = spawn(bin, ["--allow-detectable-tools"], { stdio: ["pipe", "pipe", "ignore"] });
 let b = "";
 const w = new Map();
 c.stdout.on("data", (d) => {

--- a/bench/run.mjs
+++ b/bench/run.mjs
@@ -17,7 +17,13 @@ const detector = "file://" + resolve(here, "detector.html");
 // headful with no injection — proven against a real detector by external.mjs.
 const child = spawn(bin, [], {
   stdio: ["pipe", "pipe", "inherit"],
-  env: { ...process.env, AB_HEADLESS: "1", AB_STEALTH: "1" },
+  env: {
+    ...process.env,
+    AB_HEADLESS: "1",
+    AB_STEALTH: "1",
+    // The harness reads detector-owned globals to collect the score.
+    AB_ALLOW_DETECTABLE_TOOLS: "1",
+  },
 });
 let buf = "";
 const waiters = new Map();

--- a/crates/ab-browser/src/lib.rs
+++ b/crates/ab-browser/src/lib.rs
@@ -11,6 +11,7 @@ pub mod stealth;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -21,7 +22,7 @@ use tokio::process::{Child, Command};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
 
-pub use pointer::{InputRoute, PointerAction, PointerLocation, PointerOutcome, PointerRequest};
+pub use pointer::{PointerAction, PointerLocation, PointerOutcome, PointerRequest};
 pub use snapshot::{DocumentIdentity, ElementRef, Snapshot};
 
 /// One logged network request/response.
@@ -343,6 +344,7 @@ impl Browser {
             pointer: Arc::new(Mutex::new(None)),
             pointer_mutation: Arc::new(tokio::sync::Mutex::new(())),
             dialog: Arc::new(Mutex::new((true, None))),
+            dialog_handler_started: Arc::new(AtomicBool::new(false)),
             routes: Arc::new(Mutex::new(RouteState::default())),
         })
     }
@@ -385,9 +387,8 @@ pub enum ReadMode {
 
 /// Action to perform on the element resolved at the bottom of an iframe chain
 /// (see `Page::descend_and_act`).
-enum FrameAction<'a> {
-    Click,
-    Fill(&'a str),
+enum FrameAction {
+    Point,
     Focus { clear: bool },
     Read(ReadMode),
 }
@@ -395,7 +396,7 @@ enum FrameAction<'a> {
 /// Split a `frame_selector` argument into a chain of CSS selectors. Chains
 /// are written Playwright-style as `"sel1 >> sel2 >> sel3"`, each hop naming
 /// the `<iframe>` to descend into next; the last selector passed separately
-/// to `iframe_click`/`iframe_fill` targets the element inside the innermost
+/// to `iframe_click`/`iframe_type` targets the element inside the innermost
 /// frame. A plain selector with no `>>` is a chain of length one (single
 /// iframe hop), matching the pre-existing single-level API.
 ///
@@ -416,8 +417,8 @@ fn split_frame_chain(frame_selector: &str) -> Vec<&str> {
 /// whitespace/`>>`-only input up front. Without this, an accidentally empty
 /// `frame_selector` (e.g. a caller-side templating bug) would silently
 /// resolve to a zero-length chain and `descend_and_act` would act directly
-/// on the *top-level* document — which for `iframe_click`/`iframe_fill`
-/// means clicking/filling something on the main page while the caller
+/// on the *top-level* document — which for iframe actions means acting on
+/// something on the main page while the caller
 /// believes they're targeting content inside an iframe.
 fn require_frame_chain(frame_selector: &str) -> Result<Vec<&str>> {
     let chain = split_frame_chain(frame_selector);
@@ -439,15 +440,11 @@ fn require_frame_chain(frame_selector: &str) -> Result<Vec<&str>> {
 /// `{ok:false, index, src, name}` describing the boundary iframe element
 /// (whose attributes remain readable even though its document does not), so
 /// the caller can resume via CDP.
-fn build_descend_js(chain: &[&str], selector: &str, action: &FrameAction<'_>) -> String {
+fn build_descend_js(chain: &[&str], selector: &str, action: &FrameAction) -> String {
     let chain_json = serde_json::to_string(chain).unwrap_or_else(|_| "[]".into());
     let sel_json = serde_json::to_string(selector).unwrap_or_else(|_| "\"\"".into());
     let act_js = match action {
-        FrameAction::Click => "el.click(); return { ok: true };".to_string(),
-        FrameAction::Fill(value) => format!(
-            "el.focus(); el.value={v}; el.dispatchEvent(new Event('input',{{bubbles:true}})); el.dispatchEvent(new Event('change',{{bubbles:true}})); return {{ ok: true }};",
-            v = serde_json::to_string(value).unwrap_or_else(|_| "\"\"".into()),
-        ),
+        FrameAction::Point => "el.scrollIntoView({block:'center',inline:'center'}); const r=el.getBoundingClientRect(); if(r.width<=0||r.height<=0) throw new Error('element has no visible box'); return {ok:true,x:offsetX+r.left+r.width/2,y:offsetY+r.top+r.height/2,halfWidth:r.width/2,halfHeight:r.height/2};".to_string(),
         FrameAction::Focus { clear } => {
             let select_js = if *clear {
                 " if (typeof el.select === 'function') el.select(); else if (typeof el.setSelectionRange === 'function') el.setSelectionRange(0, (el.value || '').length);"
@@ -462,24 +459,34 @@ fn build_descend_js(chain: &[&str], selector: &str, action: &FrameAction<'_>) ->
                 .to_string()
         }
     };
+    let locate = matches!(action, FrameAction::Point);
     format!(
         r#"(() => {{
   const chain = {chain_json};
+  const locate = {locate};
   let doc = document;
+  let offsetX = 0, offsetY = 0;
   for (let i = 0; i < chain.length; i++) {{
     const f = doc.querySelector(chain[i]);
     if (!f) throw new Error('iframe not found at step ' + i + ': ' + chain[i]);
+    if (locate) {{
+      f.scrollIntoView({{block:'center',inline:'center'}});
+      const r = f.getBoundingClientRect();
+      offsetX += r.left + (f.clientLeft || 0);
+      offsetY += r.top + (f.clientTop || 0);
+    }}
     let inner = null;
     try {{ inner = f.contentDocument; }} catch (e) {{ inner = null; }}
     if (!inner) {{
-      return {{ ok: false, index: i, src: f.src || f.getAttribute('src') || '', name: f.name || f.getAttribute('name') || '' }};
+      return {{ ok: false, index: i, src: f.src || f.getAttribute('src') || '', name: f.name || f.getAttribute('name') || '', offsetX, offsetY }};
     }}
     doc = inner;
   }}
   const el = doc.querySelector({sel_json});
   if (!el) throw new Error('element not found: ' + {sel_json});
   {act_js}
-}})()"#
+}})()"#,
+        locate = locate,
     )
 }
 
@@ -621,6 +628,8 @@ pub struct Page {
     pointer_mutation: Arc<tokio::sync::Mutex<()>>,
     /// JS-dialog handling policy: (accept, prompt_text). Read by the auto-handler.
     dialog: Arc<Mutex<(bool, Option<String>)>>,
+    /// Whether explicit dialog handling has installed its Page-domain listener.
+    dialog_handler_started: Arc<AtomicBool>,
     /// Network mock rules + intercept-loop state.
     routes: Arc<Mutex<RouteState>>,
 }
@@ -1183,6 +1192,31 @@ impl Page {
         }))
     }
 
+    async fn resolve_object_in_context(
+        &self,
+        backend: i64,
+        execution_context_id: i64,
+    ) -> Result<Option<String>> {
+        let res = self
+            .client
+            .send_on(
+                &self.session_id,
+                "DOM.resolveNode",
+                json!({
+                    "backendNodeId": backend,
+                    "executionContextId": execution_context_id,
+                }),
+            )
+            .await;
+        Ok(res.ok().and_then(|response| {
+            response
+                .get("object")
+                .and_then(|object| object.get("objectId"))
+                .and_then(Value::as_str)
+                .map(String::from)
+        }))
+    }
+
     /// Move the pointer to (x, y) like a human: a curved (cubic-Bézier) path
     /// with many small steps (~1 per few px, matching a real ~60-120 Hz
     /// pointer), an ease-in-out velocity profile, per-step jitter, and a final
@@ -1271,8 +1305,9 @@ impl Page {
         tokio::time::sleep(Duration::from_millis(rand_u64(30, 80))).await;
     }
 
-    /// Focus a node and enter text. Long text uses one `Input.insertText`
-    /// command; shorter text retains human-like per-character key events.
+    /// Focus a node and enter text. Long text uses one trusted
+    /// `Input.insertText` command, matching a paste/IME-style workflow;
+    /// shorter text retains humanized per-character key events.
     pub async fn type_text(&self, backend: i64, text: &str, clear: bool) -> Result<()> {
         self.type_text_cancellable(backend, text, clear, &CancellationToken::new())
             .await
@@ -1466,39 +1501,63 @@ impl Page {
         }
     }
 
-    /// Click an element inside an iframe. `frame_selector` may chain multiple
+    /// Click an element inside an iframe with trusted browser-generated pointer
+    /// input. `frame_selector` may chain multiple
     /// CSS selectors with `>>` to descend through nested iframes (e.g.
     /// `"iframe.wrapper >> iframe.popup"`). Same-origin frames are resolved
-    /// with a single main-world JS round trip; if a cross-origin boundary is
+    /// with isolated-world DOM access; if a cross-origin boundary is
     /// hit, resolution automatically falls back to CDP (`Page.getFrameTree` +
     /// `Page.createIsolatedWorld`), which is not subject to the Same-Origin
-    /// Policy. See `descend_and_act` for the mechanism.
+    /// Policy. The resolved element box is translated into top-level viewport
+    /// coordinates before CDP mouse press/release events are dispatched.
     pub async fn iframe_click(&self, frame_selector: &str, selector: &str) -> Result<()> {
         let chain = require_frame_chain(frame_selector)?;
-        self.descend_and_act(&chain, selector, &FrameAction::Click)
+        // The first pass brings every frame and the target into view. A deep
+        // target scroll can move an ancestor browsing context, so resolve once
+        // more after scrolling and dispatch only from the stable coordinates.
+        self.descend_and_act_with_session(&chain, selector, &FrameAction::Point)
             .await?;
-        Ok(())
-    }
-
-    /// Fill an input inside an iframe. See `iframe_click` for the
-    /// same-origin/cross-origin resolution behavior and the `>>` chaining
-    /// syntax for nested iframes.
-    pub async fn iframe_fill(
-        &self,
-        frame_selector: &str,
-        selector: &str,
-        value: &str,
-    ) -> Result<()> {
-        let chain = require_frame_chain(frame_selector)?;
-        self.descend_and_act(&chain, selector, &FrameAction::Fill(value))
+        let (point, session_id) = self
+            .descend_and_act_with_session(&chain, selector, &FrameAction::Point)
             .await?;
-        Ok(())
+        let x = point
+            .get("x")
+            .and_then(Value::as_f64)
+            .ok_or_else(|| BrowserError::Protocol("iframe target has no viewport x".into()))?;
+        let y = point
+            .get("y")
+            .and_then(Value::as_f64)
+            .ok_or_else(|| BrowserError::Protocol("iframe target has no viewport y".into()))?;
+        let half_width = point
+            .get("halfWidth")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0);
+        let half_height = point
+            .get("halfHeight")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0);
+        let dx = off_center(half_width);
+        let dy = off_center(half_height);
+        let root_point = (x + dx, y + dy);
+        if session_id == self.session_id {
+            self.trusted_click_at(root_point.0, root_point.1).await
+        } else {
+            let local_x = point
+                .get("localX")
+                .and_then(Value::as_f64)
+                .ok_or_else(|| BrowserError::Protocol("iframe target has no local x".into()))?;
+            let local_y = point
+                .get("localY")
+                .and_then(Value::as_f64)
+                .ok_or_else(|| BrowserError::Protocol("iframe target has no local y".into()))?;
+            self.trusted_frame_click_at(&session_id, root_point, (local_x + dx, local_y + dy))
+                .await
+        }
     }
 
     /// Focus an input inside a same-origin, cross-origin, or OOPIF iframe and
-    /// type through CDP's Input domain. Unlike `iframe_fill`, this does not
-    /// assign `element.value` or synthesize DOM events, so controlled inputs
-    /// receive the browser-generated keyboard/input event sequence.
+    /// type through CDP's Input domain. Controlled inputs receive the
+    /// browser-generated keyboard/input event sequence.
     pub async fn iframe_type_text_cancellable(
         &self,
         frame_selector: &str,
@@ -1556,7 +1615,7 @@ impl Page {
         &self,
         chain: &[&str],
         selector: &str,
-        action: &FrameAction<'_>,
+        action: &FrameAction,
     ) -> Result<Value> {
         self.descend_and_act_with_session(chain, selector, action)
             .await
@@ -1570,23 +1629,43 @@ impl Page {
         &self,
         chain: &[&str],
         selector: &str,
-        action: &FrameAction<'_>,
+        action: &FrameAction,
     ) -> Result<(Value, String)> {
         let mut context: Option<FrameExecutionContext> = None;
         let mut remaining: Vec<&str> = chain.to_vec();
+        let mut root_offset_x = 0.0;
+        let mut root_offset_y = 0.0;
         // Bound the loop: at most one CDP hop per chain element, plus one.
         for _ in 0..=chain.len() {
             let js = build_descend_js(&remaining, selector, action);
-            let result = match context.as_ref() {
-                None => self.evaluate_main(&js).await?,
+            let mut result = match context.as_ref() {
+                None => self.evaluate(&js).await?,
                 Some(ctx) => self.eval_with_context(&js, ctx).await?,
             };
             if result.get("ok").and_then(Value::as_bool) == Some(true) {
+                if matches!(action, FrameAction::Point) {
+                    let local_x = result.get("x").and_then(Value::as_f64).ok_or_else(|| {
+                        BrowserError::Protocol("iframe point result has no x".into())
+                    })?;
+                    let local_y = result.get("y").and_then(Value::as_f64).ok_or_else(|| {
+                        BrowserError::Protocol("iframe point result has no y".into())
+                    })?;
+                    if let Some(object) = result.as_object_mut() {
+                        object.insert("localX".into(), json!(local_x));
+                        object.insert("localY".into(), json!(local_y));
+                        object.insert("x".into(), json!(root_offset_x + local_x));
+                        object.insert("y".into(), json!(root_offset_y + local_y));
+                    }
+                }
                 let session_id = context
                     .as_ref()
                     .map(|ctx| ctx.session_id.clone())
                     .unwrap_or_else(|| self.session_id.clone());
                 return Ok((result, session_id));
+            }
+            if matches!(action, FrameAction::Point) {
+                root_offset_x += result.get("offsetX").and_then(Value::as_f64).unwrap_or(0.0);
+                root_offset_y += result.get("offsetY").and_then(Value::as_f64).unwrap_or(0.0);
             }
             let index = result.get("index").and_then(Value::as_u64).unwrap_or(0) as usize;
             let src = result
@@ -1981,6 +2060,10 @@ impl Page {
 
     /// Press a single named key (e.g. "Enter", "Tab", "Escape").
     pub async fn press(&self, key: &str) -> Result<()> {
+        self.press_key_on(&self.session_id, key).await
+    }
+
+    async fn press_key_on(&self, session_id: &str, key: &str) -> Result<()> {
         let (code, vk) = match key {
             "Enter" => ("Enter", 13),
             "Tab" => ("Tab", 9),
@@ -1988,22 +2071,65 @@ impl Page {
             "Backspace" => ("Backspace", 8),
             "ArrowDown" => ("ArrowDown", 40),
             "ArrowUp" => ("ArrowUp", 38),
+            "Home" => ("Home", 36),
+            "End" => ("End", 35),
             _ => (key, 0),
         };
-        for kind in ["keyDown", "keyUp"] {
+        self.client
+            .send_on(
+                session_id,
+                "Input.dispatchKeyEvent",
+                json!({
+                    "type": "keyDown",
+                    "key": code,
+                    "code": code,
+                    "windowsVirtualKeyCode": vk,
+                    "nativeVirtualKeyCode": vk,
+                }),
+            )
+            .await?;
+        tokio::time::sleep(Duration::from_millis(rand_u64(25, 95))).await;
+        self.client
+            .send_on(
+                session_id,
+                "Input.dispatchKeyEvent",
+                json!({
+                    "type": "keyUp",
+                    "key": code,
+                    "code": code,
+                    "windowsVirtualKeyCode": vk,
+                    "nativeVirtualKeyCode": vk,
+                }),
+            )
+            .await?;
+        tokio::time::sleep(Duration::from_millis(rand_u64(45, 140))).await;
+        Ok(())
+    }
+
+    async fn type_select_search_on(&self, session_id: &str, label: &str) -> Result<()> {
+        for ch in label.to_lowercase().chars() {
+            let key = ch.to_string();
             self.client
                 .send_on(
-                    &self.session_id,
+                    session_id,
                     "Input.dispatchKeyEvent",
                     json!({
-                        "type": kind,
-                        "key": code,
-                        "code": code,
-                        "windowsVirtualKeyCode": vk,
-                        "nativeVirtualKeyCode": vk,
+                        "type": "keyDown",
+                        "text": key,
+                        "key": key,
+                        "unmodifiedText": key,
                     }),
                 )
                 .await?;
+            tokio::time::sleep(Duration::from_millis(rand_u64(25, 85))).await;
+            self.client
+                .send_on(
+                    session_id,
+                    "Input.dispatchKeyEvent",
+                    json!({ "type": "keyUp", "key": key }),
+                )
+                .await?;
+            tokio::time::sleep(Duration::from_millis(rand_u64(35, 120))).await;
         }
         Ok(())
     }
@@ -2011,26 +2137,98 @@ impl Page {
 
 /// More navigation / interaction primitives (parity with mature drivers).
 impl Page {
-    /// Set the value of a <select> by ref and fire input/change events.
+    /// Select one enabled option using trusted browser-generated keyboard input.
     pub async fn select_option(&self, backend: i64, value: &str) -> Result<()> {
         self.scroll_into_view(backend).await;
+        let frame_id = self.main_frame_id().await?;
+        let context_id = self
+            .create_world_in_session(&self.session_id, &frame_id)
+            .await?;
         let obj = self
-            .resolve_object(backend)
+            .resolve_object_in_context(backend, context_id)
             .await?
             .ok_or_else(|| BrowserError::Protocol("cannot resolve element".into()))?;
-        self.client
+        let result = async {
+            let inspected = self
+                .client
+                .send_on(
+                    &self.session_id,
+                    "Runtime.callFunctionOn",
+                    json!({
+                        "objectId": obj,
+                        "arguments": [{ "value": value }],
+                        "functionDeclaration": "function(v){if(this.tagName!=='SELECT')return{error:'target is not a select'};if(this.disabled)return{error:'select is disabled'};if(this.multiple)return{error:'multiple select is not supported by trusted single-option input'};const enabled=Array.from(this.options).filter(o=>!o.disabled&&!(o.parentElement&&o.parentElement.tagName==='OPTGROUP'&&o.parentElement.disabled));const target=enabled.find(o=>o.value===v);if(!target)return{error:'enabled option value not found'};return{currentValue:this.value,targetLabel:target.label||target.textContent||''};}",
+                        "returnByValue": true,
+                    }),
+                )
+                .await?;
+            if let Some(exception) = inspected.get("exceptionDetails") {
+                return Err(BrowserError::Protocol(format!(
+                    "select inspection failed: {exception}"
+                )));
+            }
+            let metadata = inspected
+                .pointer("/result/value")
+                .ok_or_else(|| BrowserError::Protocol("select inspection returned no value".into()))?;
+            if let Some(error) = metadata.get("error").and_then(Value::as_str) {
+                return Err(BrowserError::Protocol(error.into()));
+            }
+            if metadata.get("currentValue").and_then(Value::as_str) == Some(value) {
+                return Ok(());
+            }
+            let target_label = metadata
+                .get("targetLabel")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|label| !label.is_empty())
+                .ok_or_else(|| BrowserError::Protocol("select target label is missing".into()))?;
+            if target_label.chars().count() > 200 {
+                return Err(BrowserError::Protocol(
+                    "select target label is too long for trusted type-ahead".into(),
+                ));
+            }
+
+            self.client
+                .send_on(
+                    &self.session_id,
+                    "DOM.focus",
+                    json!({ "backendNodeId": backend }),
+                )
+                .await?;
+            self.type_select_search_on(&self.session_id, target_label)
+                .await?;
+
+            let verified = self
+                .client
+                .send_on(
+                    &self.session_id,
+                    "Runtime.callFunctionOn",
+                    json!({
+                        "objectId": obj,
+                        "functionDeclaration": "function(){return this.value;}",
+                        "returnByValue": true,
+                    }),
+                )
+                .await?;
+            let actual = verified.pointer("/result/value").and_then(Value::as_str);
+            if actual != Some(value) {
+                return Err(BrowserError::Protocol(format!(
+                    "trusted select input chose {:?}, expected {value:?}",
+                    actual.unwrap_or("")
+                )));
+            }
+            Ok(())
+        }
+        .await;
+        let _ = self
+            .client
             .send_on(
                 &self.session_id,
-                "Runtime.callFunctionOn",
-                json!({
-                    "objectId": obj,
-                    "arguments": [{ "value": value }],
-                    "functionDeclaration":
-                        "function(v){ this.value = v; this.dispatchEvent(new Event('input',{bubbles:true})); this.dispatchEvent(new Event('change',{bubbles:true})); }",
-                }),
+                "Runtime.releaseObject",
+                json!({ "objectId": obj }),
             )
-            .await?;
-        Ok(())
+            .await;
+        result
     }
 
     /// Install a CDP virtual authenticator so WebAuthn / passkey prompts are
@@ -2487,12 +2685,19 @@ impl Page {
         Ok(())
     }
 
-    /// Auto-accept JavaScript dialogs (alert/confirm/prompt) so automation never
-    /// blocks on them. Enables the Page domain and handles openings as they come.
-    pub async fn enable_dialog_auto_accept(&self) -> Result<()> {
-        self.client
+    /// Start the explicit JavaScript-dialog handler. Idempotent per page.
+    pub async fn enable_dialog_handler(&self) -> Result<bool> {
+        if self.dialog_handler_started.swap(true, Ordering::AcqRel) {
+            return Ok(false);
+        }
+        if let Err(error) = self
+            .client
             .send_on(&self.session_id, "Page.enable", json!({}))
-            .await?;
+            .await
+        {
+            self.dialog_handler_started.store(false, Ordering::Release);
+            return Err(error.into());
+        }
         let mut rx = self.client.events();
         let sid = self.session_id.clone();
         let client = self.client.clone();
@@ -2517,14 +2722,17 @@ impl Page {
                 }
             }
         });
-        Ok(())
+        Ok(true)
     }
 
     /// Set how the next JS dialogs (alert/confirm/prompt/beforeunload) are
-    /// handled: accept vs dismiss, plus optional prompt text. Applies to the
-    /// running auto-handler; default is accept.
+    /// handled: accept vs dismiss, plus optional prompt text.
     pub fn set_dialog_policy(&self, accept: bool, prompt_text: Option<String>) {
         *self.dialog.lock().unwrap() = (accept, prompt_text);
+    }
+
+    pub fn dialog_handler_enabled(&self) -> bool {
+        self.dialog_handler_started.load(Ordering::Acquire)
     }
 
     /// Draw a highlight box over an element (debug/inspection aid).
@@ -2855,7 +3063,7 @@ mod tests {
     };
 
     #[test]
-    fn long_text_uses_insert_text_by_unicode_character_count() {
+    fn long_text_uses_atomic_trusted_insertion_by_unicode_character_count() {
         assert!(!uses_insert_text(&"한".repeat(29)));
         assert!(uses_insert_text(&"한".repeat(30)));
         assert!(uses_insert_text(&"a".repeat(30)));
@@ -2890,23 +3098,25 @@ mod tests {
     }
 
     #[test]
-    fn descend_js_embeds_chain_and_selector_as_json_and_performs_click() {
-        let js = build_descend_js(&["iframe#f"], "button#go", &FrameAction::Click);
+    fn descend_js_locates_iframe_target_without_synthetic_clicks() {
+        let js = build_descend_js(&["iframe#f"], "button#go", &FrameAction::Point);
         assert!(js.contains(r#"["iframe#f"]"#));
         assert!(js.contains(r#"querySelector("button#go")"#));
-        assert!(js.contains("el.click();"));
+        assert!(js.contains("getBoundingClientRect"));
+        assert!(js.contains("offsetX"));
+        assert!(!js.contains("el.click();"));
+        assert!(!js.contains("dispatchEvent"));
         assert!(js.contains("ok: false"));
-        assert!(js.contains("ok: true"));
+        assert!(js.contains("ok:true"));
     }
 
     #[test]
-    fn descend_js_fill_sets_value_and_dispatches_events() {
-        let js = build_descend_js(&[], "input#q", &FrameAction::Fill("hello \"world\""));
-        // No frame hops: chain is empty, so it should act directly.
+    fn point_lookup_on_current_document_returns_a_box_only() {
+        let js = build_descend_js(&[], "button#go", &FrameAction::Point);
         assert!(js.contains(r#"const chain = [];"#));
-        assert!(js.contains(r#"el.value="hello \"world\"";"#));
-        assert!(js.contains("dispatchEvent(new Event('input'"));
-        assert!(js.contains("dispatchEvent(new Event('change'"));
+        assert!(js.contains("halfWidth"));
+        assert!(js.contains("halfHeight"));
+        assert!(!js.contains("dispatchEvent"));
     }
 
     #[test]

--- a/crates/ab-browser/src/pointer.rs
+++ b/crates/ab-browser/src/pointer.rs
@@ -1,13 +1,12 @@
 //! Unified browser-internal pointer actions.
 //!
-//! Trusted input retains browser-rs's humanized CDP path. DOM events are an
-//! explicit, untrusted background compatibility route and never an automatic
-//! fallback.
+//! All input uses browser-generated CDP events. Synthetic DOM-event delivery is
+//! intentionally absent because it exposes isTrusted == false to page scripts.
 
 use std::time::Duration;
 
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde_json::json;
 
 use crate::{rand_u64, BrowserError, ElementRef, Page, Result};
 
@@ -38,25 +37,6 @@ impl PointerAction {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum InputRoute {
-    Trusted,
-    DomEvent,
-}
-
-impl InputRoute {
-    pub fn parse(value: &str) -> Result<Self> {
-        match value {
-            "trusted" => Ok(Self::Trusted),
-            "dom_event" => Ok(Self::DomEvent),
-            _ => Err(BrowserError::Protocol(format!(
-                "unknown input route {value:?}"
-            ))),
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub enum PointerLocation {
     Element(ElementRef),
@@ -66,7 +46,6 @@ pub enum PointerLocation {
 #[derive(Debug, Clone)]
 pub struct PointerRequest {
     pub action: PointerAction,
-    pub route: InputRoute,
     pub origin: PointerLocation,
     pub destination: Option<PointerLocation>,
     pub delta_x: f64,
@@ -76,7 +55,6 @@ pub struct PointerRequest {
 #[derive(Debug, Clone, Serialize)]
 pub struct PointerOutcome {
     pub action: PointerAction,
-    pub route: InputRoute,
     pub trusted: bool,
     pub dispatched: bool,
     /// `changed`, `unchanged`, or `unknown`.
@@ -89,10 +67,7 @@ impl Page {
         validate_request(request)?;
         let _mutation = self.pointer_mutation.lock().await;
         self.validate_pointer_refs(request).await?;
-        match request.route {
-            InputRoute::Trusted => self.dispatch_trusted_pointer(request).await,
-            InputRoute::DomEvent => self.dispatch_dom_pointer(request).await,
-        }
+        self.dispatch_trusted_pointer(request).await
     }
 
     async fn validate_pointer_refs(&self, request: &PointerRequest) -> Result<()> {
@@ -153,12 +128,7 @@ impl Page {
 
         match request.action {
             PointerAction::Click => {
-                tokio::time::sleep(Duration::from_millis(rand_u64(20, 70))).await;
-                self.mouse_button("mousePressed", x, y, "left", 1, 1)
-                    .await?;
-                tokio::time::sleep(Duration::from_millis(rand_u64(40, 110))).await;
-                self.mouse_button("mouseReleased", x, y, "left", 0, 1)
-                    .await?;
+                self.left_click_at(x, y).await?;
             }
             PointerAction::Hover => {}
             PointerAction::RightClick => {
@@ -221,7 +191,6 @@ impl Page {
 
         Ok(PointerOutcome {
             action: request.action,
-            route: request.route,
             trusted: true,
             dispatched: true,
             observed: "unknown",
@@ -266,9 +235,23 @@ impl Page {
         buttons: u8,
         click_count: u8,
     ) -> Result<()> {
+        self.mouse_button_on(&self.session_id, kind, x, y, button, (buttons, click_count))
+            .await
+    }
+
+    async fn mouse_button_on(
+        &self,
+        session_id: &str,
+        kind: &str,
+        x: f64,
+        y: f64,
+        button: &str,
+        state: (u8, u8),
+    ) -> Result<()> {
+        let (buttons, click_count) = state;
         self.client
             .send_on(
-                &self.session_id,
+                session_id,
                 "Input.dispatchMouseEvent",
                 json!({
                     "type": kind, "x": x, "y": y, "button": button,
@@ -279,101 +262,47 @@ impl Page {
         Ok(())
     }
 
-    async fn dispatch_dom_pointer(&self, request: &PointerRequest) -> Result<PointerOutcome> {
-        let PointerLocation::Element(origin) = &request.origin else {
-            return Err(BrowserError::Protocol(
-                "dom_event pointer actions require a snapshot ref".into(),
-            ));
-        };
-        let object_id = self
-            .resolve_object(origin.backend_node_id)
-            .await?
-            .ok_or_else(|| BrowserError::Protocol("pointer ref has no live object".into()))?;
+    async fn left_click_at(&self, x: f64, y: f64) -> Result<()> {
+        self.left_click_at_on(&self.session_id, x, y).await
+    }
 
-        let (function, arguments) = match request.action {
-            PointerAction::Click => (
-                "function(){const el=this;const base={bubbles:true,cancelable:true,composed:true,button:0,pointerId:1,pointerType:'mouse',isPrimary:true,view:el.ownerDocument.defaultView};const down={...base,buttons:1};const up={...base,buttons:0};el.dispatchEvent(new PointerEvent('pointerover',down));el.dispatchEvent(new PointerEvent('pointerenter',{...down,bubbles:false}));el.dispatchEvent(new MouseEvent('mouseover',down));el.dispatchEvent(new PointerEvent('pointerdown',down));el.dispatchEvent(new MouseEvent('mousedown',down));try{el.focus&&el.focus();}catch(_){}el.dispatchEvent(new PointerEvent('pointerup',up));el.dispatchEvent(new MouseEvent('mouseup',up));el.dispatchEvent(new MouseEvent('click',up));return true;}",
-                json!([]),
-            ),
-            PointerAction::Hover => (
-                "function(){const o={bubbles:true,composed:true,view:this.ownerDocument.defaultView};this.dispatchEvent(new PointerEvent('pointerover',o));this.dispatchEvent(new PointerEvent('pointerenter',{...o,bubbles:false}));this.dispatchEvent(new MouseEvent('mouseover',o));this.dispatchEvent(new MouseEvent('mouseenter',{...o,bubbles:false}));return true;}",
-                json!([]),
-            ),
-            PointerAction::RightClick => (
-                "function(){const o={bubbles:true,cancelable:true,composed:true,button:2,buttons:2,view:this.ownerDocument.defaultView};this.dispatchEvent(new PointerEvent('pointerdown',o));this.dispatchEvent(new MouseEvent('mousedown',o));this.dispatchEvent(new MouseEvent('mouseup',{...o,buttons:0}));this.dispatchEvent(new PointerEvent('pointerup',{...o,buttons:0}));this.dispatchEvent(new MouseEvent('contextmenu',{...o,buttons:0}));return true;}",
-                json!([]),
-            ),
-            PointerAction::DoubleClick => (
-                "function(){const o={bubbles:true,cancelable:true,composed:true,button:0,view:this.ownerDocument.defaultView};for(let detail=1;detail<=2;detail++){this.dispatchEvent(new PointerEvent('pointerdown',{...o,buttons:1,detail}));this.dispatchEvent(new MouseEvent('mousedown',{...o,buttons:1,detail}));this.dispatchEvent(new MouseEvent('mouseup',{...o,buttons:0,detail}));this.dispatchEvent(new PointerEvent('pointerup',{...o,buttons:0,detail}));this.dispatchEvent(new MouseEvent('click',{...o,buttons:0,detail}));}this.dispatchEvent(new MouseEvent('dblclick',{...o,buttons:0,detail:2}));return true;}",
-                json!([]),
-            ),
-            PointerAction::Scroll => (
-                "function(dx,dy){const o={deltaX:dx,deltaY:dy,bubbles:true,cancelable:true,composed:true,view:this.ownerDocument.defaultView};this.dispatchEvent(new WheelEvent('wheel',o));let n=this;while(n&&n!==this.ownerDocument.documentElement){const s=this.ownerDocument.defaultView.getComputedStyle(n);if(/(auto|scroll)/.test(s.overflow+s.overflowX+s.overflowY))break;n=n.parentElement;}const target=n||this.ownerDocument.scrollingElement||this.ownerDocument.documentElement;const bx=target.scrollLeft,by=target.scrollTop;target.scrollBy(dx,dy);return target.scrollLeft!==bx||target.scrollTop!==by;}",
-                json!([{ "value": request.delta_x }, { "value": request.delta_y }]),
-            ),
-            PointerAction::Drag => {
-                let destination = request.destination.as_ref().expect("validated drag");
-                let args = match destination {
-                    PointerLocation::Element(element) => {
-                        let destination_id = self
-                            .resolve_object(element.backend_node_id)
-                            .await?
-                            .ok_or_else(|| BrowserError::Protocol("drag destination is stale".into()))?;
-                        json!([{ "objectId": destination_id }, { "value": Value::Null }, { "value": Value::Null }])
-                    }
-                    PointerLocation::Coordinates { x, y } => {
-                        json!([{ "value": Value::Null }, { "value": x }, { "value": y }])
-                    }
-                };
-                (
-                    "function(destination,x,y){const doc=this.ownerDocument,dest=destination||doc.elementFromPoint(x,y);if(!dest||dest.ownerDocument!==doc)return false;let data=null;try{data=new DataTransfer();}catch(_){}const o={bubbles:true,cancelable:true,composed:true};this.dispatchEvent(new PointerEvent('pointerdown',{...o,button:0,buttons:1}));this.dispatchEvent(new MouseEvent('mousedown',{...o,button:0,buttons:1}));this.dispatchEvent(new DragEvent('dragstart',{...o,dataTransfer:data}));dest.dispatchEvent(new DragEvent('dragenter',{...o,dataTransfer:data}));dest.dispatchEvent(new DragEvent('dragover',{...o,dataTransfer:data}));dest.dispatchEvent(new DragEvent('drop',{...o,dataTransfer:data}));this.dispatchEvent(new DragEvent('dragend',{...o,dataTransfer:data}));dest.dispatchEvent(new MouseEvent('mouseup',{...o,button:0,buttons:0}));dest.dispatchEvent(new PointerEvent('pointerup',{...o,button:0,buttons:0}));return true;}",
-                    args,
-                )
-            }
-        };
-
-        let response = self
-            .client
-            .send_on(
-                &self.session_id,
-                "Runtime.callFunctionOn",
-                json!({
-                    "objectId": object_id,
-                    "functionDeclaration": function,
-                    "arguments": arguments,
-                    "returnByValue": true,
-                }),
-            )
+    async fn left_click_at_on(&self, session_id: &str, x: f64, y: f64) -> Result<()> {
+        tokio::time::sleep(Duration::from_millis(rand_u64(20, 70))).await;
+        self.mouse_button_on(session_id, "mousePressed", x, y, "left", (1, 1))
             .await?;
-        if let Some(exception) = response.get("exceptionDetails") {
-            return Err(BrowserError::Protocol(format!(
-                "DOM pointer event raised an exception: {exception}"
-            )));
-        }
-        let result = response.pointer("/result/value").and_then(Value::as_bool);
-        if matches!(request.action, PointerAction::Scroll | PointerAction::Drag)
-            && result != Some(true)
-        {
-            let reason = if request.action == PointerAction::Scroll {
-                "synthetic scroll target did not move"
-            } else {
-                "synthetic drag destination did not resolve in the same document"
-            };
-            return Err(BrowserError::Protocol(reason.into()));
-        }
+        tokio::time::sleep(Duration::from_millis(rand_u64(40, 110))).await;
+        self.mouse_button_on(session_id, "mouseReleased", x, y, "left", (0, 1))
+            .await
+    }
 
-        Ok(PointerOutcome {
-            action: request.action,
-            route: request.route,
-            trusted: false,
-            dispatched: true,
-            observed: if request.action == PointerAction::Scroll {
-                "changed"
-            } else {
-                "unknown"
-            },
-            retryable: false,
-        })
+    pub(crate) async fn trusted_click_at(&self, x: f64, y: f64) -> Result<()> {
+        if !x.is_finite() || !y.is_finite() || x < 0.0 || y < 0.0 {
+            return Err(BrowserError::Protocol(
+                "trusted click coordinates must be finite and non-negative".into(),
+            ));
+        }
+        let _mutation = self.pointer_mutation.lock().await;
+        self.human_move_to(x, y).await?;
+        self.left_click_at(x, y).await
+    }
+
+    pub(crate) async fn trusted_frame_click_at(
+        &self,
+        session_id: &str,
+        root_point: (f64, f64),
+        frame_point: (f64, f64),
+    ) -> Result<()> {
+        for value in [root_point.0, root_point.1, frame_point.0, frame_point.1] {
+            if !value.is_finite() || value < 0.0 {
+                return Err(BrowserError::Protocol(
+                    "trusted frame click coordinates must be finite and non-negative".into(),
+                ));
+            }
+        }
+        let _mutation = self.pointer_mutation.lock().await;
+        self.human_move_to(root_point.0, root_point.1).await?;
+        self.left_click_at_on(session_id, frame_point.0, frame_point.1)
+            .await
     }
 }
 
@@ -415,13 +344,6 @@ fn validate_request(request: &PointerRequest) -> Result<()> {
     {
         return Err(BrowserError::Protocol("only scroll accepts deltas".into()));
     }
-    if request.route == InputRoute::DomEvent
-        && !matches!(request.origin, PointerLocation::Element(_))
-    {
-        return Err(BrowserError::Protocol(
-            "dom_event requires a snapshot ref".into(),
-        ));
-    }
     Ok(())
 }
 
@@ -433,7 +355,6 @@ mod tests {
     fn request(action: PointerAction) -> PointerRequest {
         PointerRequest {
             action,
-            route: InputRoute::Trusted,
             origin: PointerLocation::Coordinates { x: 10.0, y: 20.0 },
             destination: None,
             delta_x: 0.0,
@@ -463,13 +384,6 @@ mod tests {
         value.delta_y = 120.0;
         assert!(validate_request(&value).is_ok());
         value.delta_y = f64::NAN;
-        assert!(validate_request(&value).is_err());
-    }
-
-    #[test]
-    fn dom_event_rejects_coordinates() {
-        let mut value = request(PointerAction::Hover);
-        value.route = InputRoute::DomEvent;
         assert!(validate_request(&value).is_err());
     }
 

--- a/crates/ab-browser/src/snapshot.rs
+++ b/crates/ab-browser/src/snapshot.rs
@@ -77,7 +77,7 @@ fn is_noise(role: &str) -> bool {
 /// (cross-origin) iframe's content is invisible to `Accessibility.getFullAXTree`
 /// entirely (separate renderer, separate CDP target) — without this line the
 /// agent would have no signal that an iframe exists at all. Use
-/// `browser_iframe_read` / `browser_iframe_click` / `browser_iframe_fill` to
+/// `browser_iframe_read` / `browser_iframe_click` / `browser_iframe_type` to
 /// reach inside it.
 fn is_iframe(role: &str) -> bool {
     matches!(role, "Iframe" | "iframe" | "IframePresentational")

--- a/crates/ab-mcp/src/http_security.rs
+++ b/crates/ab-mcp/src/http_security.rs
@@ -101,7 +101,7 @@ impl HttpSecurity {
         }
     }
 
-    async fn authorize_request(&self, auth: RequestAuth) -> Result<Option<String>, Response> {
+    async fn authorize_request(&self, auth: RequestAuth) -> Result<Option<String>, Box<Response>> {
         let RequestAuth {
             path,
             provided,
@@ -118,44 +118,50 @@ impl HttpSecurity {
                     .as_deref()
                     .is_some_and(|value| constant_time_eq(value, expected))
                 {
-                    return Err(unauthorized("invalid browser capability"));
+                    return Err(Box::new(unauthorized("invalid browser capability")));
                 }
             }
             return Ok(None);
         }
 
         let Some(root) = self.root_capability.as_deref() else {
-            return Err(unauthorized("browser capability is unavailable"));
+            return Err(Box::new(unauthorized("browser capability is unavailable")));
         };
         if path == "/owners" {
             if !provided
                 .as_deref()
                 .is_some_and(|value| constant_time_eq(value, root))
             {
-                return Err(unauthorized("invalid browser administrative capability"));
+                return Err(Box::new(unauthorized(
+                    "invalid browser administrative capability",
+                )));
             }
             return Ok(None);
         }
 
         let Some(owner) = owner else {
-            return Err((StatusCode::BAD_REQUEST, "browser owner is required").into_response());
+            return Err(Box::new(
+                (StatusCode::BAD_REQUEST, "browser owner is required").into_response(),
+            ));
         };
         let expected = owner_capability(root, &owner);
         if !provided
             .as_deref()
             .is_some_and(|value| constant_time_eq(value, &expected))
         {
-            return Err(unauthorized("invalid browser owner capability"));
+            return Err(Box::new(unauthorized("invalid browser owner capability")));
         }
 
         if let Some(session_id) = session_id {
             let owners = self.session_owners.lock().await;
             if owners.get(&session_id) != Some(&owner) {
-                return Err((
-                    StatusCode::FORBIDDEN,
-                    "browser owner does not match this session",
-                )
-                    .into_response());
+                return Err(Box::new(
+                    (
+                        StatusCode::FORBIDDEN,
+                        "browser owner does not match this session",
+                    )
+                        .into_response(),
+                ));
             }
         }
         Ok(Some(owner))
@@ -247,7 +253,7 @@ pub async fn authorize_http(security: HttpSecurity, request: Request, next: Next
     let request_session = request_session(&request);
     let owner = match security.authorize_request(request_auth(&request)).await {
         Ok(owner) => owner,
-        Err(response) => return response,
+        Err(response) => return *response,
     };
 
     let method = request.method().clone();

--- a/crates/ab-mcp/src/main.rs
+++ b/crates/ab-mcp/src/main.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock, Weak};
 
 use ab_browser::{
-    Browser, ConsoleLog, ElementRef, InputRoute, LaunchOptions, NetworkLog, Page, PointerAction,
+    Browser, ConsoleLog, ElementRef, LaunchOptions, NetworkLog, Page, PointerAction,
     PointerLocation, PointerRequest,
 };
 use rmcp::handler::server::{router::tool::ToolRouter, tool::ToolCallContext, wrapper::Parameters};
@@ -37,8 +37,12 @@ Loop: browser_navigate -> browser_snapshot -> act (click/type) -> re-snapshot to
 - browser_activate_page explicitly foregrounds a tab and verifies visibility.
 - browser_wheel sends native CDP mouse-wheel input for lazy-loaded feeds.
 - refs go stale when the page changes — re-snapshot before reusing them.
-- browser_evaluate runs one-shot JS; browser_take_screenshot saves a PNG.
-Stealth: default paths avoid Runtime.enable; browser_console_messages opts in on first use."#;
+- browser_evaluate runs one-shot JS in an isolated world; browser_take_screenshot saves a PNG.
+Stealth: observable diagnostics are blocked by default. Start with
+--allow-detectable-tools only when main-world JS or Runtime-enabled console
+capture is explicitly required. All interaction tools use trusted CDP input."#;
+
+const DETECTABLE_TOOLS: &[&str] = &["browser_console_messages"];
 
 tokio::task_local! {
     static REQUEST_OWNER: Option<String>;
@@ -68,6 +72,30 @@ fn parse_allowed_tools(value: Option<String>) -> Option<HashSet<String>> {
             .map(str::to_string)
             .collect()
     })
+}
+
+fn env_flag_enabled(name: &str) -> bool {
+    std::env::var(name).is_ok_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+fn detectable_argument_violation(request: &CallToolRequestParams) -> Option<&'static str> {
+    let arguments = request.arguments.as_ref()?;
+    match request.name.as_ref() {
+        "browser_evaluate"
+            if arguments
+                .get("main_world")
+                .and_then(serde_json::Value::as_bool)
+                == Some(true) =>
+        {
+            Some("browser_evaluate main_world=true executes in the page's observable JS world")
+        }
+        _ => None,
+    }
 }
 
 fn force_scoped_owner_argument(request: &mut CallToolRequestParams, owner: &str) {
@@ -108,12 +136,11 @@ fn release_owner_claim(
     Some(page)
 }
 
-fn webauthn_options_match_automatic_defaults(
-    transport: &str,
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct WebAuthnConfig {
+    transport: String,
     user_verified: bool,
     resident_key: bool,
-) -> bool {
-    transport == "internal" && user_verified && resident_key
 }
 
 struct PageEntry {
@@ -123,7 +150,7 @@ struct PageEntry {
     active_typing: Option<Weak<CancellationToken>>,
     netlog: Option<NetworkLog>,
     consolelog: Option<ConsoleLog>,
-    webauthn_authenticator_id: Option<String>,
+    webauthn_authenticator: Option<(String, WebAuthnConfig)>,
 }
 
 /// Order-insensitive line diff: what appeared / disappeared between snapshots.
@@ -229,6 +256,7 @@ struct BrowserServer {
     tool_router: ToolRouter<Self>,
     default_owner: Option<String>,
     allowed_tools: Option<Arc<HashSet<String>>>,
+    allow_detectable_tools: bool,
     secret_broker: Option<secret_broker::SecretBroker>,
 }
 
@@ -298,9 +326,6 @@ struct PointerArgs {
     page: String,
     /// click, hover, right_click, double_click, scroll, or drag.
     action: String,
-    /// trusted (default) or dom_event. dom_event is untrusted and requires ref.
-    #[serde(default)]
-    input_route: Option<String>,
     #[serde(default, rename = "ref")]
     ref_: Option<String>,
     #[serde(default)]
@@ -625,19 +650,6 @@ struct IframeClickArgs {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-struct IframeFillArgs {
-    page: String,
-    /// CSS selector for the <iframe> element, or a " >> "-separated chain
-    /// for nested iframes. Same-origin and cross-origin frames are both
-    /// supported and require no special handling from the caller. See the
-    /// `frame_selector` known-limitations note above this struct.
-    frame_selector: String,
-    /// CSS selector for the input inside the innermost iframe.
-    selector: String,
-    value: String,
-}
-
-#[derive(Debug, Deserialize, JsonSchema)]
 struct IframeTypeArgs {
     page: String,
     /// CSS selector for the <iframe> element, or a " >> "-separated chain
@@ -739,6 +751,10 @@ fn validate_wheel_input(delta_y: f64, x: f64, y: f64) -> Result<(), &'static str
     Ok(())
 }
 
+fn webdriver_value_is_human(value: &serde_json::Value) -> bool {
+    matches!(value.as_str(), Some("undefined" | "false"))
+}
+
 impl BrowserServer {
     #[cfg(test)]
     fn new() -> Self {
@@ -755,16 +771,37 @@ impl BrowserServer {
             tool_router: Self::tool_router(),
             default_owner,
             allowed_tools: configured_allowed_tools(),
+            allow_detectable_tools: env_flag_enabled("AB_ALLOW_DETECTABLE_TOOLS"),
             secret_broker,
         }
     }
 
     fn tool_is_allowed(&self, name: &str) -> bool {
         name.starts_with("browser_")
+            && (self.allow_detectable_tools || !DETECTABLE_TOOLS.contains(&name))
             && self
                 .allowed_tools
                 .as_ref()
                 .is_none_or(|allowed| allowed.contains(name))
+    }
+
+    fn enforce_detectable_argument_policy(
+        &self,
+        request: &CallToolRequestParams,
+    ) -> Result<(), McpError> {
+        if self.allow_detectable_tools {
+            return Ok(());
+        }
+        if let Some(reason) = detectable_argument_violation(request) {
+            return Err(McpError::invalid_request(
+                format!(
+                    "detectable browser path blocked by strict mode: {reason}; restart with \
+                     --allow-detectable-tools to opt in"
+                ),
+                None,
+            ));
+        }
+        Ok(())
     }
 
     fn resolve_page_id(st: &State, id_or_owner: &str) -> Option<String> {
@@ -1038,12 +1075,6 @@ impl BrowserServer {
                 .await
                 .map_err(fail)?;
             let netlog = page.enable_network_log().await.ok();
-            let _ = page.enable_dialog_auto_accept().await;
-            let webauthn_authenticator_id = Some(
-                page.webauthn_enable("internal", true, true)
-                    .await
-                    .map_err(fail)?,
-            );
             let snap = page.snapshot().await.map_err(fail)?;
             st.next += 1;
             let id = format!("p{}", st.next);
@@ -1056,7 +1087,7 @@ impl BrowserServer {
                     active_typing: None,
                     netlog,
                     consolelog: None,
-                    webauthn_authenticator_id,
+                    webauthn_authenticator: None,
                 },
             );
             if let Some(owner) = inherited_owner {
@@ -1132,14 +1163,6 @@ impl BrowserServer {
             .await
             .map_err(fail)?;
         let netlog = page.enable_network_log().await.ok();
-        let _ = page.enable_dialog_auto_accept().await;
-        // Install before navigation so a page cannot open a native passkey
-        // chooser during its first load and block browser automation.
-        let webauthn_authenticator_id = Some(
-            page.webauthn_enable("internal", true, true)
-                .await
-                .map_err(fail)?,
-        );
         if !url.is_empty() && url != "about:blank" {
             page.navigate(url).await.map_err(fail)?;
         }
@@ -1155,7 +1178,7 @@ impl BrowserServer {
                 active_typing: None,
                 netlog,
                 consolelog: None,
-                webauthn_authenticator_id,
+                webauthn_authenticator: None,
             },
         );
         if let Some(owner) = request_owner() {
@@ -1260,7 +1283,6 @@ impl BrowserServer {
         let origin = page.element_ref_for_backend(backend).await.map_err(fail)?;
         page.dispatch_pointer(&PointerRequest {
             action: PointerAction::Click,
-            route: InputRoute::Trusted,
             origin: PointerLocation::Element(origin),
             destination: None,
             delta_x: 0.0,
@@ -1286,7 +1308,6 @@ impl BrowserServer {
         let page = self.page_of(&page_id).await?;
         page.dispatch_pointer(&PointerRequest {
             action: PointerAction::Scroll,
-            route: InputRoute::Trusted,
             origin: PointerLocation::Coordinates { x: a.x, y: a.y },
             destination: None,
             delta_x: 0.0,
@@ -1306,9 +1327,9 @@ impl BrowserServer {
         .unwrap_or_else(|_| "{}".into())))
     }
 
-    /// Extended pointer actions with explicit trusted or synthetic DOM delivery.
+    /// Extended pointer actions using trusted browser-generated input.
     #[tool(
-        description = "Click, hover, right-click, double-click, scroll, or drag by ref/selector/coordinates. trusted is default; dom_event is explicitly untrusted and requires a snapshot ref"
+        description = "Click, hover, right-click, double-click, scroll, or drag by ref/selector/coordinates using trusted CDP input"
     )]
     async fn browser_pointer(
         &self,
@@ -1317,11 +1338,6 @@ impl BrowserServer {
         let page_id = self.canonical_page_id(&a.page).await?;
         let page = self.page_of(&page_id).await?;
         let action = PointerAction::parse(&a.action).map_err(fail)?;
-        let route =
-            InputRoute::parse(a.input_route.as_deref().unwrap_or("trusted")).map_err(fail)?;
-        if route == InputRoute::DomEvent && a.ref_.is_none() {
-            return Err(fail("input_route=dom_event requires `ref` for the origin"));
-        }
         let origin = self
             .pointer_location(
                 &page_id,
@@ -1351,7 +1367,6 @@ impl BrowserServer {
             .await?;
         let request = PointerRequest {
             action,
-            route,
             origin,
             destination,
             delta_x: a.delta_x.unwrap_or(0.0),
@@ -1558,8 +1573,10 @@ impl BrowserServer {
         let page = self.page_of(&a.page).await?;
         let accept = a.accept.unwrap_or(true);
         page.set_dialog_policy(accept, a.prompt_text.clone());
+        let started = page.enable_dialog_handler().await.map_err(fail)?;
         Ok(ok(format!(
-            "dialogs on {} will be {}{}",
+            "dialog handling {} on {}; upcoming dialogs will be {}{}",
+            if started { "enabled" } else { "updated" },
             a.page,
             if accept { "accepted" } else { "dismissed" },
             a.prompt_text
@@ -1668,7 +1685,6 @@ impl BrowserServer {
         let destination = page.element_ref_for_backend(to).await.map_err(fail)?;
         page.dispatch_pointer(&PointerRequest {
             action: PointerAction::Drag,
-            route: InputRoute::Trusted,
             origin: PointerLocation::Element(origin),
             destination: Some(PointerLocation::Element(destination)),
             delta_x: 0.0,
@@ -1902,7 +1918,6 @@ impl BrowserServer {
         let origin = page.element_ref_for_backend(backend).await.map_err(fail)?;
         page.dispatch_pointer(&PointerRequest {
             action: PointerAction::Hover,
-            route: InputRoute::Trusted,
             origin: PointerLocation::Element(origin),
             destination: None,
             delta_x: 0.0,
@@ -1914,8 +1929,10 @@ impl BrowserServer {
         Ok(ok(format!("hovered on {}\n\n{}", a.page, diff)))
     }
 
-    /// Select an <option> in a dropdown by ref + value.
-    #[tool(description = "Select a dropdown option by ref and value; returns settle-diff")]
+    /// Select an <option> using trusted browser-generated keyboard input.
+    #[tool(
+        description = "Select an enabled dropdown option by value using trusted CDP keyboard input; returns settle-diff"
+    )]
     async fn browser_select_option(
         &self,
         Parameters(a): Parameters<SelectArgs>,
@@ -1939,38 +1956,49 @@ impl BrowserServer {
         Parameters(a): Parameters<WebAuthnArgs>,
     ) -> Result<CallToolResult, McpError> {
         let page_id = self.canonical_page_id(&a.page).await?;
-        let (page, existing_id) = {
+        let (page, existing) = {
             let st = self.state.lock().await;
             let entry = st
                 .pages
                 .get(&page_id)
                 .ok_or_else(|| fail(format!("unknown page or owner '{}'", a.page)))?;
-            (entry.page.clone(), entry.webauthn_authenticator_id.clone())
+            (entry.page.clone(), entry.webauthn_authenticator.clone())
         };
-        let transport = a.transport.as_deref().unwrap_or("internal");
-        let user_verified = a.user_verified.unwrap_or(true);
-        let resident_key = a.resident_key.unwrap_or(true);
-        let (id, actual_transport, already_installed) = if let Some(id) = existing_id {
-            if !webauthn_options_match_automatic_defaults(transport, user_verified, resident_key) {
+        let requested = WebAuthnConfig {
+            transport: a.transport.unwrap_or_else(|| "internal".into()),
+            user_verified: a.user_verified.unwrap_or(true),
+            resident_key: a.resident_key.unwrap_or(true),
+        };
+        let (id, already_installed) = if let Some((id, installed)) = existing {
+            if installed != requested {
                 return Err(fail(
-                    "this page already has the automatic WebAuthn authenticator (transport=internal, user_verified=true, resident_key=true); replacing it is not supported",
+                    format!(
+                        "this page already has a WebAuthn authenticator \
+                         (transport={}, user_verified={}, resident_key={}); replacing it is not supported",
+                        installed.transport, installed.user_verified, installed.resident_key
+                    ),
                 ));
             }
-            (id, "internal", true)
+            (id, true)
         } else {
             let id = page
-                .webauthn_enable(transport, user_verified, resident_key)
+                .webauthn_enable(
+                    &requested.transport,
+                    requested.user_verified,
+                    requested.resident_key,
+                )
                 .await
                 .map_err(fail)?;
             if let Some(entry) = self.state.lock().await.pages.get_mut(&page_id) {
-                entry.webauthn_authenticator_id = Some(id.clone());
+                entry.webauthn_authenticator = Some((id.clone(), requested.clone()));
             }
-            (id, transport, false)
+            (id, false)
         };
         Ok(ok(format!(
-            "virtual authenticator {} on {} (transport={actual_transport}, authenticatorId={id}). Passkey prompts will no longer block; sites fall back to password when no credential matches.",
+            "virtual authenticator {} on {} (transport={}, authenticatorId={id}). Passkey prompts will no longer block; sites fall back to password when no credential matches.",
             if already_installed { "already installed" } else { "installed" },
             a.page,
+            requested.transport,
         )))
     }
 
@@ -2147,6 +2175,40 @@ impl BrowserServer {
                     .count()
             },
         );
+        let virtual_authenticators = request_owner().map_or_else(
+            || {
+                st.pages
+                    .values()
+                    .filter(|entry| entry.webauthn_authenticator.is_some())
+                    .count()
+            },
+            |owner| {
+                st.pages
+                    .iter()
+                    .filter(|(page_id, entry)| {
+                        entry.webauthn_authenticator.is_some()
+                            && st.page_owners.get(*page_id) == Some(&owner)
+                    })
+                    .count()
+            },
+        );
+        let dialog_handlers = request_owner().map_or_else(
+            || {
+                st.pages
+                    .values()
+                    .filter(|entry| entry.page.dialog_handler_enabled())
+                    .count()
+            },
+            |owner| {
+                st.pages
+                    .iter()
+                    .filter(|(page_id, entry)| {
+                        entry.page.dialog_handler_enabled()
+                            && st.page_owners.get(*page_id) == Some(&owner)
+                    })
+                    .count()
+            },
+        );
         let mode = if std::env::var("AB_CONNECT").is_ok() {
             "connect"
         } else if std::env::var("AB_HEADLESS").is_ok() {
@@ -2158,8 +2220,13 @@ impl BrowserServer {
         } else {
             "headful (be-real)"
         };
+        let detectable_diagnostics = if self.allow_detectable_tools {
+            "allowed (explicit opt-in)"
+        } else {
+            "blocked (strict default)"
+        };
         Ok(ok(format!(
-            "running: {running}\nmode: {mode}\nopen pages: {open_pages}"
+            "running: {running}\nmode: {mode}\ndetectable diagnostics: {detectable_diagnostics}\nopen pages: {open_pages}\nvirtual authenticators: {virtual_authenticators}\ndialog handlers: {dialog_handlers}"
         )))
     }
 
@@ -2201,10 +2268,9 @@ impl BrowserServer {
         }))
     }
 
-    /// Click an element inside an iframe (same-origin or cross-origin,
-    /// including nested chains via " >> ").
+    /// Click inside an iframe with trusted browser-generated pointer input.
     #[tool(
-        description = "Click an element inside an iframe. Handles same-origin and cross-origin frames automatically; chain nested iframes in frame_selector with ' >> '"
+        description = "Click an element inside a same-origin or cross-origin iframe using trusted CDP pointer input; chain nested iframes in frame_selector with ' >> '"
     )]
     async fn browser_iframe_click(
         &self,
@@ -2216,22 +2282,6 @@ impl BrowserServer {
             .map_err(fail)?;
         let diff = self.settle_diff(&a.page, &page).await?;
         Ok(ok(format!("iframe-clicked on {}\n\n{}", a.page, diff)))
-    }
-
-    /// Fill an input inside an iframe (same-origin or cross-origin,
-    /// including nested chains via " >> ").
-    #[tool(
-        description = "Fill an input inside an iframe. Handles same-origin and cross-origin frames automatically; chain nested iframes in frame_selector with ' >> '"
-    )]
-    async fn browser_iframe_fill(
-        &self,
-        Parameters(a): Parameters<IframeFillArgs>,
-    ) -> Result<CallToolResult, McpError> {
-        let page = self.page_of(&a.page).await?;
-        page.iframe_fill(&a.frame_selector, &a.selector, &a.value)
-            .await
-            .map_err(fail)?;
-        Ok(ok(format!("iframe-filled on {}", a.page)))
     }
 
     /// Type into an input inside an iframe using trusted CDP keyboard input.
@@ -2555,7 +2605,7 @@ impl BrowserServer {
 
         let wd = get("webdriver");
         checks.push((
-            wd.as_str() == Some("undefined"),
+            webdriver_value_is_human(&wd),
             format!("navigator.webdriver = {wd}"),
         ));
         let plugins = get("plugins").as_u64().unwrap_or(0);
@@ -2619,6 +2669,7 @@ impl rmcp::ServerHandler for BrowserServer {
         if let Some(owner) = owner.as_ref() {
             force_scoped_owner_argument(&mut request, owner);
         }
+        self.enforce_detectable_argument_policy(&request)?;
         let broker_context = if let Some(broker) = self.secret_broker.as_ref() {
             let input = serde_json::Value::Object(request.arguments.clone().unwrap_or_default());
             let transformed = broker
@@ -2751,12 +2802,13 @@ Options:\n\
   --user-data-dir <path>   Persistent browser profile directory\n\
   --headless / --headed    Run headless or headful (default headful)\n\
   --stealth                Inject the JS stealth-patch layer (for headless)\n\
+  --allow-detectable-tools Allow main-world JS and Runtime-enabled console capture\n\
   --connect <port|url>     Attach to a Chrome already running with\n\
                            --remote-debugging-port (identical fingerprint)\n\
   -h, --help               Show this help\n\
   -V, --version            Show the browser-rs version\n\
 \n\
-Env equivalents: AB_HTTP, AB_HTTP_CAPABILITY, AB_PROFILE, AB_HEADLESS, AB_STEALTH, AB_CONNECT, AB_CHROME.\n";
+Env equivalents: AB_HTTP, AB_HTTP_CAPABILITY, AB_PROFILE, AB_HEADLESS, AB_STEALTH, AB_CONNECT, AB_CHROME, AB_ALLOW_DETECTABLE_TOOLS.\n";
 
 #[cfg(test)]
 mod tests {
@@ -2764,7 +2816,7 @@ mod tests {
         bind_address_is_loopback, constant_time_secret_eq, enforce_scoped_owner,
         force_scoped_owner_argument, parse_allowed_tools, parse_cli_from, parse_connect_port,
         release_owner_claim, snapshot_diff, truncate_text, validate_wheel_input,
-        webauthn_options_match_automatic_defaults, BrowserServer, IframeTypeArgs, State, TypeArgs,
+        webdriver_value_is_human, BrowserServer, IframeTypeArgs, State, TypeArgs, WebAuthnConfig,
         DEFAULT_MAX_OUTPUT_LIMIT, REQUEST_OWNER,
     };
     use rmcp::model::CallToolRequestParams;
@@ -2868,6 +2920,54 @@ mod tests {
     }
 
     #[test]
+    fn strict_mode_hides_observable_console_diagnostics_only() {
+        let mut server = BrowserServer::new();
+        server.allow_detectable_tools = false;
+        assert!(!server.tool_is_allowed("browser_console_messages"));
+        assert!(server.tool_is_allowed("browser_click"));
+        assert!(server.tool_is_allowed("browser_evaluate"));
+        assert!(server.tool_is_allowed("browser_iframe_click"));
+        assert!(server.tool_is_allowed("browser_select_option"));
+
+        server.allow_detectable_tools = true;
+        assert!(server.tool_is_allowed("browser_console_messages"));
+    }
+
+    #[test]
+    fn strict_mode_rejects_detectable_options_inside_allowed_tools() {
+        let mut server = BrowserServer::new();
+        server.allow_detectable_tools = false;
+        let request = |tool: &'static str, arguments: serde_json::Value| {
+            CallToolRequestParams::new(tool).with_arguments(
+                arguments
+                    .as_object()
+                    .expect("test arguments must be an object")
+                    .clone(),
+            )
+        };
+
+        assert!(server
+            .enforce_detectable_argument_policy(&request(
+                "browser_evaluate",
+                serde_json::json!({"page":"p1", "expression":"1", "main_world":true})
+            ))
+            .is_err());
+        assert!(server
+            .enforce_detectable_argument_policy(&request(
+                "browser_evaluate",
+                serde_json::json!({"page":"p1", "expression":"1"})
+            ))
+            .is_ok());
+        server.allow_detectable_tools = true;
+        assert!(server
+            .enforce_detectable_argument_policy(&request(
+                "browser_evaluate",
+                serde_json::json!({"page":"p1", "expression":"1", "main_world":true})
+            ))
+            .is_ok());
+    }
+
+    #[test]
     fn scoped_claim_and_release_arguments_cannot_select_another_owner() {
         for tool in ["browser_claim_page", "browser_release_page"] {
             let mut request =
@@ -2896,6 +2996,17 @@ mod tests {
     }
 
     #[test]
+    fn cli_parser_accepts_detectable_tools_opt_in() {
+        std::env::remove_var("AB_ALLOW_DETECTABLE_TOOLS");
+        parse_cli_from(["--allow-detectable-tools"].into_iter().map(str::to_string)).unwrap();
+        assert_eq!(
+            std::env::var("AB_ALLOW_DETECTABLE_TOOLS").as_deref(),
+            Ok("1")
+        );
+        std::env::remove_var("AB_ALLOW_DETECTABLE_TOOLS");
+    }
+
+    #[test]
     fn cli_parser_rejects_missing_invalid_and_unknown_options() {
         for args in [vec!["--port"], vec!["--port", "0"], vec!["--porrt", "9321"]] {
             assert!(parse_cli_from(args.into_iter().map(str::to_string)).is_err());
@@ -2919,19 +3030,21 @@ mod tests {
     }
 
     #[test]
-    fn automatic_webauthn_options_are_not_silently_reconfigured() {
-        assert!(webauthn_options_match_automatic_defaults(
-            "internal", true, true
-        ));
-        assert!(!webauthn_options_match_automatic_defaults(
-            "usb", true, true
-        ));
-        assert!(!webauthn_options_match_automatic_defaults(
-            "internal", false, true
-        ));
-        assert!(!webauthn_options_match_automatic_defaults(
-            "internal", true, false
-        ));
+    fn explicit_webauthn_config_distinguishes_incompatible_reinstall_requests() {
+        let installed = WebAuthnConfig {
+            transport: "internal".into(),
+            user_verified: true,
+            resident_key: true,
+        };
+        assert_eq!(installed, installed.clone());
+        assert_ne!(
+            installed,
+            WebAuthnConfig {
+                transport: "usb".into(),
+                user_verified: true,
+                resident_key: true,
+            }
+        );
     }
 
     #[test]
@@ -2985,6 +3098,13 @@ mod tests {
         assert!(validate_wheel_input(700.0, 650.0, -1.0).is_err());
         assert!(validate_wheel_input(f64::INFINITY, 650.0, 500.0).is_err());
         assert!(validate_wheel_input(700.0, f64::NAN, 500.0).is_err());
+    }
+
+    #[test]
+    fn webdriver_false_and_undefined_are_both_human_browser_states() {
+        assert!(webdriver_value_is_human(&serde_json::json!("undefined")));
+        assert!(webdriver_value_is_human(&serde_json::json!("false")));
+        assert!(!webdriver_value_is_human(&serde_json::json!("true")));
     }
 }
 
@@ -3064,6 +3184,9 @@ fn parse_cli_from(args: impl IntoIterator<Item = String>) -> anyhow::Result<Cli>
             "--headless" if inline_value.is_none() => std::env::set_var("AB_HEADLESS", "1"),
             "--headed" if inline_value.is_none() => std::env::remove_var("AB_HEADLESS"),
             "--stealth" if inline_value.is_none() => std::env::set_var("AB_STEALTH", "1"),
+            "--allow-detectable-tools" if inline_value.is_none() => {
+                std::env::set_var("AB_ALLOW_DETECTABLE_TOOLS", "1")
+            }
             "--connect" | "--cdp-endpoint" => {
                 let port = parse_connect_port(&option_value(&mut it, inline_value, flag)?)?;
                 std::env::set_var("AB_CONNECT", port.to_string());

--- a/scripts/mcp-smoke.mjs
+++ b/scripts/mcp-smoke.mjs
@@ -104,23 +104,20 @@ if (!firstRef) {
   child.kill();
   throw new Error("navigation snapshot had no interactive ref");
 }
-for (const inputRoute of ["trusted", "dom_event"]) {
-  const hover = await send("tools/call", {
-    name: "browser_pointer",
-    arguments: {
-      page: "p1",
-      action: "hover",
-      input_route: inputRoute,
-      ref: firstRef,
-    },
-  });
-  if (hover.result?.isError || hover.error) {
-    child.kill();
-    throw new Error(`${inputRoute} pointer hover failed: ${JSON.stringify(hover)}`);
-  }
-  console.log(`browser_pointer hover (${inputRoute}):`, hover.result?.content?.[0]?.text);
-  firstRef = await freshRef();
+const hover = await send("tools/call", {
+  name: "browser_pointer",
+  arguments: {
+    page: "p1",
+    action: "hover",
+    ref: firstRef,
+  },
+});
+if (hover.result?.isError || hover.error) {
+  child.kill();
+  throw new Error(`trusted pointer hover failed: ${JSON.stringify(hover)}`);
 }
+console.log("browser_pointer hover (trusted):", hover.result?.content?.[0]?.text);
+firstRef = await freshRef();
 const click = await send("tools/call", {
   name: "browser_click",
   arguments: { page: "p1", ref: firstRef },


### PR DESCRIPTION
## Summary
- make strict anti-detection policy the default while keeping console/main-world diagnostics opt-in
- remove synthetic pointer routing and browser_iframe_fill
- upgrade iframe click and native select to trusted CDP input
- make WebAuthn and JavaScript dialog handling explicit opt-ins
- release as browser-rs 0.2.0

## Breaking changes
- browser_pointer no longer accepts input_route
- browser_iframe_fill is removed
- browser_console_messages is hidden unless detectable tools are explicitly enabled

## Verification
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- stealth benchmark 13/13
- Rebrowser detector: no red detections
- detection-lab OOPIF click/select/long-text E2E passes