### PR TITLE
release: v0.2.1 input-layer and stealth hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ab-browser"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ab-cdp",
  "anyhow",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "ab-cdp"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "futures-util",
  "serde",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "ab-mcp"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ab-browser",
  "ab-cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/ab-cdp", "crates/ab-browser", "crates/ab-mcp"]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,7 +22,7 @@ browser-rs --help
 
 ```bash
 # Pin a specific version
-curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | AB_VERSION=v0.2.0 sh
+curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | AB_VERSION=v0.2.1 sh
 
 # Choose the install directory
 AB_BIN_DIR=~/bin curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | sh

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ browser-rs --help
 To pin this release instead of following `latest`:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | AB_VERSION=v0.2.0 sh
+curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | AB_VERSION=v0.2.1 sh
 ```
 
 **2. Run** — use stdio for a client that launches the server:
@@ -90,7 +90,18 @@ cargo install --git https://github.com/maestrojeong/browser-rs-mcp ab-mcp
 Set `AB_CHROME` if Chrome is not in a standard location.
 
 <details>
-<summary><strong>What's new (v0.1.14 - v0.2.0)</strong></summary>
+<summary><strong>What's new (v0.1.14 - v0.2.1)</strong></summary>
+
+**v0.2.1 — input-layer and stealth hardening.** Character key events now carry
+a real US-QWERTY `code`/`windowsVirtualKeyCode`/`nativeVirtualKeyCode` alongside
+`key`/`text`, closing the `KeyboardEvent.code === ""` / `keyCode === 0` tell.
+Long (>=30 char) input now emulates a human Ctrl/Cmd+V paste gesture (trusted
+modifier+V key events around the text delivery) instead of a bare, keyless
+`Input.insertText`. The JS stealth-patch layer now injects by default in both
+headful and headless launches (self-guarding; opt out with `AB_NO_STEALTH=1`),
+gained a more realistic `chrome.runtime`/`chrome.csi`/`chrome.loadTimes` shim,
+and `browser_fingerprint_check` now also reports WebGL renderer, speech-voice,
+`window.chrome`, notification-permission, and viewport-sanity signals.
 
 **v0.2.0 — trusted-only interaction defaults.** Synthetic pointer delivery and
 `browser_iframe_fill` have been removed. `browser_iframe_click` now resolves
@@ -423,13 +434,15 @@ browser-rs --port 9321 [options]    # HTTP MCP transport
   --headless               Run headless
   --headed                 Run headful (default)
   --connect <port|url>     Attach to an existing Chrome
-  --stealth                Enable the JS fallback layer
+  --stealth                Compatibility no-op (enabled by default)
   --allow-detectable-tools Opt in to observable debugging paths
 ```
 
 `--port` enables HTTP mode; without it, the server uses stdio. The equivalent
 environment variables are `AB_HTTP`, `AB_PROFILE`, `AB_HEADLESS`, `AB_CONNECT`,
-`AB_STEALTH`, `AB_CHROME`, and `AB_ALLOW_DETECTABLE_TOOLS`.
+`AB_NO_STEALTH`, `AB_CHROME`, and `AB_ALLOW_DETECTABLE_TOOLS`. Set
+`AB_NO_STEALTH=1` to disable initialization-script injection for launched
+browsers; `--connect` browsers are always left untouched.
 `AB_HTTP_CAPABILITY` protects HTTP/SSE requests with `X-Browser-Capability`
 and is required for non-loopback binds.
 

--- a/crates/ab-browser/src/lib.rs
+++ b/crates/ab-browser/src/lib.rs
@@ -111,9 +111,9 @@ pub struct LaunchOptions {
     /// Headless is a strong fingerprint tell. Off by default — a real headful
     /// window on real hardware is what makes the fingerprint match a human's.
     pub headless: bool,
-    /// Inject the JS stealth-patching layer. Off by default: patching each
-    /// property is itself an anomaly that sophisticated defenses flag. Only
-    /// turn this on as a best-effort fallback when forced to run headless.
+    /// Inject the self-guarding JS stealth layer into launched browsers.
+    /// Enabled by default for both headful and headless launches; callers can
+    /// disable it when an entirely untouched browser surface is required.
     pub inject_stealth: bool,
     pub chrome_path: Option<PathBuf>,
     /// Persistent profile directory. A stable, aged profile (cookies, history)
@@ -129,7 +129,7 @@ impl Default for LaunchOptions {
     fn default() -> Self {
         Self {
             headless: false,
-            inject_stealth: false,
+            inject_stealth: true,
             chrome_path: None,
             user_data_dir: None,
             port: 0, // 0 => let Chrome pick, we read it back from DevToolsActivePort
@@ -156,11 +156,11 @@ impl Browser {
 
     /// Launch Chrome and connect over CDP.
     ///
-    /// Default mode is headful with a persistent profile and NO JS patching, so
-    /// the page's fingerprint is that of a real, human-driven Chrome. Only the
-    /// `AutomationControlled` blink feature is disabled (a launch flag, not a
-    /// page-visible patch) so `navigator.webdriver` is naturally false.
+    /// Default mode is headful with a persistent profile and the self-guarding
+    /// stealth initialization script. The `AutomationControlled` blink feature
+    /// is also disabled so `navigator.webdriver` is naturally false.
     pub async fn launch(opts: LaunchOptions) -> Result<Self> {
+        let inject_stealth = opts.inject_stealth && std::env::var("AB_NO_STEALTH").is_err();
         let chrome = opts
             .chrome_path
             .clone()
@@ -227,7 +227,7 @@ impl Browser {
 
         // A UA override is only needed to hide the "Headless" token, i.e. only
         // when we're forced to run headless. Headful reports a real UA.
-        let user_agent = if opts.inject_stealth && opts.headless {
+        let user_agent = if inject_stealth && opts.headless {
             client
                 .send("Browser.getVersion", json!({}))
                 .await
@@ -243,7 +243,7 @@ impl Browser {
             client,
             child: Some(child),
             user_agent,
-            inject_stealth: opts.inject_stealth,
+            inject_stealth,
         })
     }
 
@@ -279,7 +279,6 @@ impl Browser {
             .to_string();
 
         let page = self.attach_page(&target_id).await?;
-        // No page patching by default: an untouched real Chrome is the goal.
         if self.inject_stealth {
             page.init_stealth().await?;
             if !self.user_agent.is_empty() {
@@ -839,7 +838,7 @@ impl Page {
                         json!({
                             "frameId": frame,
                             "worldName": "ab_isolated",
-                            "grantUniveralAccess": false,
+                            "grantUniversalAccess": false,
                         }),
                     )
                     .await
@@ -1368,7 +1367,7 @@ impl Page {
                     .send_on(
                         session_id,
                         "Input.dispatchKeyEvent",
-                        json!({ "type": kind, "key": "Delete", "code": "Delete", "windowsVirtualKeyCode": 46 }),
+                        json!({ "type": kind, "key": "Delete", "code": "Delete", "windowsVirtualKeyCode": 46, "nativeVirtualKeyCode": 46, "modifiers": 0 }),
                     )
                     .await?;
             }
@@ -1376,10 +1375,9 @@ impl Page {
 
         ensure_typing_active(cancel)?;
         if uses_insert_text(text) {
-            self.client
-                .send_on(session_id, "Input.insertText", json!({ "text": text }))
-                .await?;
-            return Ok(());
+            return self
+                .dispatch_paste_cancellable(session_id, text, cancel)
+                .await;
         }
 
         let mut shift_held = false;
@@ -1391,6 +1389,7 @@ impl Page {
                 return Err(BrowserError::TypingCancelled);
             }
             let s = ch.to_string();
+            let (code, vk) = us_qwerty_key(ch);
             let need_shift = needs_shift(ch);
             // Real keyboards produce shifted chars (uppercase, @, !, …) only
             // while Shift is physically held. Detectors flag e.g. "@ typed
@@ -1400,7 +1399,7 @@ impl Page {
                     .send_on(
                         session_id,
                         "Input.dispatchKeyEvent",
-                        json!({ "type": "keyDown", "key": "Shift", "code": "ShiftLeft", "modifiers": 8 }),
+                        json!({ "type": "keyDown", "key": "Shift", "code": "ShiftLeft", "windowsVirtualKeyCode": 16, "nativeVirtualKeyCode": 16, "modifiers": 8 }),
                     )
                     .await?;
                 shift_held = true;
@@ -1417,7 +1416,7 @@ impl Page {
                 .send_on(
                     session_id,
                     "Input.dispatchKeyEvent",
-                    json!({ "type": "keyDown", "text": s, "key": s, "unmodifiedText": s, "modifiers": modifiers }),
+                    json!({ "type": "keyDown", "text": s, "key": s, "unmodifiedText": s, "code": code, "windowsVirtualKeyCode": vk, "nativeVirtualKeyCode": vk, "modifiers": modifiers }),
                 )
                 .await?;
             // Key hold time (press duration), then release.
@@ -1426,7 +1425,7 @@ impl Page {
                 .send_on(
                     session_id,
                     "Input.dispatchKeyEvent",
-                    json!({ "type": "keyUp", "key": s, "modifiers": modifiers }),
+                    json!({ "type": "keyUp", "key": s, "code": code, "windowsVirtualKeyCode": vk, "nativeVirtualKeyCode": vk, "modifiers": modifiers }),
                 )
                 .await?;
             if cancelled {
@@ -1459,12 +1458,96 @@ impl Page {
         Ok(())
     }
 
+    async fn dispatch_paste_cancellable(
+        &self,
+        session_id: &str,
+        text: &str,
+        cancel: &CancellationToken,
+    ) -> Result<()> {
+        ensure_typing_active(cancel)?;
+        typing_delay(cancel, rand_u64(90, 240)).await?;
+
+        #[cfg(target_os = "macos")]
+        let (modifier_key, modifier_code, modifier_vk, modifiers) = ("Meta", "MetaLeft", 91, 4);
+        #[cfg(not(target_os = "macos"))]
+        let (modifier_key, modifier_code, modifier_vk, modifiers) =
+            ("Control", "ControlLeft", 17, 2);
+
+        self.client
+            .send_on(
+                session_id,
+                "Input.dispatchKeyEvent",
+                json!({ "type": "keyDown", "key": modifier_key, "code": modifier_code, "windowsVirtualKeyCode": modifier_vk, "nativeVirtualKeyCode": modifier_vk, "modifiers": modifiers }),
+            )
+            .await?;
+        if typing_delay(cancel, rand_u64(20, 55)).await.is_err() {
+            self.release_modifier_on(session_id, modifier_key, modifier_code, modifier_vk)
+                .await?;
+            return Err(BrowserError::TypingCancelled);
+        }
+
+        self.client
+            .send_on(
+                session_id,
+                "Input.dispatchKeyEvent",
+                json!({ "type": "keyDown", "key": "v", "code": "KeyV", "windowsVirtualKeyCode": 86, "nativeVirtualKeyCode": 86, "modifiers": modifiers }),
+            )
+            .await?;
+        let cancelled = typing_delay(cancel, rand_u64(25, 75)).await.is_err();
+        self.client
+            .send_on(
+                session_id,
+                "Input.dispatchKeyEvent",
+                json!({ "type": "keyUp", "key": "v", "code": "KeyV", "windowsVirtualKeyCode": 86, "nativeVirtualKeyCode": 86, "modifiers": modifiers }),
+            )
+            .await?;
+        if cancelled {
+            self.release_modifier_on(session_id, modifier_key, modifier_code, modifier_vk)
+                .await?;
+            return Err(BrowserError::TypingCancelled);
+        }
+
+        if typing_delay(cancel, rand_u64(10, 35)).await.is_err() {
+            self.release_modifier_on(session_id, modifier_key, modifier_code, modifier_vk)
+                .await?;
+            return Err(BrowserError::TypingCancelled);
+        }
+        self.release_modifier_on(session_id, modifier_key, modifier_code, modifier_vk)
+            .await?;
+        ensure_typing_active(cancel)?;
+
+        // CDP cannot populate a trusted ClipboardEvent's clipboardData without
+        // an OS clipboard or observable main-world JS. insertText carries the
+        // content after the trusted shortcut while preserving stealth policy.
+        self.client
+            .send_on(session_id, "Input.insertText", json!({ "text": text }))
+            .await?;
+        Ok(())
+    }
+
+    async fn release_modifier_on(
+        &self,
+        session_id: &str,
+        key: &str,
+        code: &str,
+        vk: u32,
+    ) -> Result<()> {
+        self.client
+            .send_on(
+                session_id,
+                "Input.dispatchKeyEvent",
+                json!({ "type": "keyUp", "key": key, "code": code, "windowsVirtualKeyCode": vk, "nativeVirtualKeyCode": vk, "modifiers": 0 }),
+            )
+            .await?;
+        Ok(())
+    }
+
     async fn release_shift_on(&self, session_id: &str) -> Result<()> {
         self.client
             .send_on(
                 session_id,
                 "Input.dispatchKeyEvent",
-                json!({ "type": "keyUp", "key": "Shift", "code": "ShiftLeft" }),
+                json!({ "type": "keyUp", "key": "Shift", "code": "ShiftLeft", "windowsVirtualKeyCode": 16, "nativeVirtualKeyCode": 16, "modifiers": 0 }),
             )
             .await?;
         Ok(())
@@ -2064,16 +2147,20 @@ impl Page {
     }
 
     async fn press_key_on(&self, session_id: &str, key: &str) -> Result<()> {
-        let (code, vk) = match key {
-            "Enter" => ("Enter", 13),
-            "Tab" => ("Tab", 9),
-            "Escape" => ("Escape", 27),
-            "Backspace" => ("Backspace", 8),
-            "ArrowDown" => ("ArrowDown", 40),
-            "ArrowUp" => ("ArrowUp", 38),
-            "Home" => ("Home", 36),
-            "End" => ("End", 35),
-            _ => (key, 0),
+        let (event_key, code, vk) = match key {
+            "Enter" => (key, "Enter", 13),
+            "Tab" => (key, "Tab", 9),
+            "Escape" => (key, "Escape", 27),
+            "Backspace" => (key, "Backspace", 8),
+            "ArrowDown" => (key, "ArrowDown", 40),
+            "ArrowUp" => (key, "ArrowUp", 38),
+            "Home" => (key, "Home", 36),
+            "End" => (key, "End", 35),
+            _ if key.chars().count() == 1 => {
+                let (code, vk) = us_qwerty_key(key.chars().next().unwrap());
+                (key, code, vk)
+            }
+            _ => (key, "", 0),
         };
         self.client
             .send_on(
@@ -2081,7 +2168,7 @@ impl Page {
                 "Input.dispatchKeyEvent",
                 json!({
                     "type": "keyDown",
-                    "key": code,
+                    "key": event_key,
                     "code": code,
                     "windowsVirtualKeyCode": vk,
                     "nativeVirtualKeyCode": vk,
@@ -2095,7 +2182,7 @@ impl Page {
                 "Input.dispatchKeyEvent",
                 json!({
                     "type": "keyUp",
-                    "key": code,
+                    "key": event_key,
                     "code": code,
                     "windowsVirtualKeyCode": vk,
                     "nativeVirtualKeyCode": vk,
@@ -2109,6 +2196,8 @@ impl Page {
     async fn type_select_search_on(&self, session_id: &str, label: &str) -> Result<()> {
         for ch in label.to_lowercase().chars() {
             let key = ch.to_string();
+            let (code, vk) = us_qwerty_key(ch);
+            let modifiers = if needs_shift(ch) { 8 } else { 0 };
             self.client
                 .send_on(
                     session_id,
@@ -2118,6 +2207,10 @@ impl Page {
                         "text": key,
                         "key": key,
                         "unmodifiedText": key,
+                        "code": code,
+                        "windowsVirtualKeyCode": vk,
+                        "nativeVirtualKeyCode": vk,
+                        "modifiers": modifiers,
                     }),
                 )
                 .await?;
@@ -2126,7 +2219,7 @@ impl Page {
                 .send_on(
                     session_id,
                     "Input.dispatchKeyEvent",
-                    json!({ "type": "keyUp", "key": key }),
+                    json!({ "type": "keyUp", "key": key, "code": code, "windowsVirtualKeyCode": vk, "nativeVirtualKeyCode": vk, "modifiers": modifiers }),
                 )
                 .await?;
             tokio::time::sleep(Duration::from_millis(rand_u64(35, 120))).await;
@@ -2945,6 +3038,61 @@ fn needs_shift(ch: char) -> bool {
     ch.is_ascii_uppercase() || "~!@#$%^&*()_+{}|:\"<>?".contains(ch)
 }
 
+fn us_qwerty_key(ch: char) -> (&'static str, u32) {
+    match ch {
+        'a' | 'A' => ("KeyA", 65),
+        'b' | 'B' => ("KeyB", 66),
+        'c' | 'C' => ("KeyC", 67),
+        'd' | 'D' => ("KeyD", 68),
+        'e' | 'E' => ("KeyE", 69),
+        'f' | 'F' => ("KeyF", 70),
+        'g' | 'G' => ("KeyG", 71),
+        'h' | 'H' => ("KeyH", 72),
+        'i' | 'I' => ("KeyI", 73),
+        'j' | 'J' => ("KeyJ", 74),
+        'k' | 'K' => ("KeyK", 75),
+        'l' | 'L' => ("KeyL", 76),
+        'm' | 'M' => ("KeyM", 77),
+        'n' | 'N' => ("KeyN", 78),
+        'o' | 'O' => ("KeyO", 79),
+        'p' | 'P' => ("KeyP", 80),
+        'q' | 'Q' => ("KeyQ", 81),
+        'r' | 'R' => ("KeyR", 82),
+        's' | 'S' => ("KeyS", 83),
+        't' | 'T' => ("KeyT", 84),
+        'u' | 'U' => ("KeyU", 85),
+        'v' | 'V' => ("KeyV", 86),
+        'w' | 'W' => ("KeyW", 87),
+        'x' | 'X' => ("KeyX", 88),
+        'y' | 'Y' => ("KeyY", 89),
+        'z' | 'Z' => ("KeyZ", 90),
+        '0' | ')' => ("Digit0", 48),
+        '1' | '!' => ("Digit1", 49),
+        '2' | '@' => ("Digit2", 50),
+        '3' | '#' => ("Digit3", 51),
+        '4' | '$' => ("Digit4", 52),
+        '5' | '%' => ("Digit5", 53),
+        '6' | '^' => ("Digit6", 54),
+        '7' | '&' => ("Digit7", 55),
+        '8' | '*' => ("Digit8", 56),
+        '9' | '(' => ("Digit9", 57),
+        ' ' => ("Space", 32),
+        '-' | '_' => ("Minus", 189),
+        '=' | '+' => ("Equal", 187),
+        '[' | '{' => ("BracketLeft", 219),
+        ']' | '}' => ("BracketRight", 221),
+        '\\' | '|' => ("Backslash", 220),
+        ';' | ':' => ("Semicolon", 186),
+        '\'' | '"' => ("Quote", 222),
+        ',' | '<' => ("Comma", 188),
+        '.' | '>' => ("Period", 190),
+        '/' | '?' => ("Slash", 191),
+        '`' | '~' => ("Backquote", 192),
+        _ => ("", 0),
+    }
+}
+
+// Short strings are typed key-by-key; long strings are more plausibly pasted.
 const INSERT_TEXT_THRESHOLD: usize = 30;
 
 fn uses_insert_text(text: &str) -> bool {
@@ -3059,7 +3207,8 @@ async fn discover_ws_url(port: u16) -> Result<String> {
 mod tests {
     use super::{
         activation_verified, build_descend_js, build_frame_element_js, require_frame_chain,
-        resolve_frame_id, split_frame_chain, uses_insert_text, FrameAction, ReadMode,
+        resolve_frame_id, split_frame_chain, us_qwerty_key, uses_insert_text, FrameAction,
+        ReadMode,
     };
 
     #[test]
@@ -3067,6 +3216,16 @@ mod tests {
         assert!(!uses_insert_text(&"한".repeat(29)));
         assert!(uses_insert_text(&"한".repeat(30)));
         assert!(uses_insert_text(&"a".repeat(30)));
+    }
+
+    #[test]
+    fn us_qwerty_mapping_covers_shifted_and_unshifted_keys() {
+        assert_eq!(us_qwerty_key('a'), ("KeyA", 65));
+        assert_eq!(us_qwerty_key('A'), ("KeyA", 65));
+        assert_eq!(us_qwerty_key('1'), ("Digit1", 49));
+        assert_eq!(us_qwerty_key('!'), ("Digit1", 49));
+        assert_eq!(us_qwerty_key('?'), ("Slash", 191));
+        assert_eq!(us_qwerty_key('한'), ("", 0));
     }
 
     #[test]

--- a/crates/ab-browser/src/stealth.rs
+++ b/crates/ab-browser/src/stealth.rs
@@ -122,13 +122,67 @@ pub const STEALTH_INIT_SCRIPT: &str = r#"
     }
   } catch (_) {}
 
-  // window.chrome runtime shim (present in real Chrome, missing when driven).
+  // Small window.chrome shim for surfaces present in normal Chrome. Define
+  // only missing pieces so a real browser/profile keeps its native objects.
   try {
     if (!window.chrome) {
       window.chrome = {};
     }
     if (!window.chrome.runtime) {
-      window.chrome.runtime = {};
+      const listener = () => ({
+        addListener: mark(function addListener() {}, 'addListener'),
+        removeListener: mark(function removeListener() {}, 'removeListener'),
+        hasListener: mark(function hasListener() { return false; }, 'hasListener'),
+      });
+      const connect = mark(function connect() {
+        const onDisconnect = listener();
+        const onMessage = listener();
+        return {
+          name: '', sender: undefined, onDisconnect, onMessage,
+          postMessage: mark(function postMessage() {}, 'postMessage'),
+          disconnect: mark(function disconnect() {}, 'disconnect'),
+        };
+      }, 'connect');
+      const sendMessage = mark(function sendMessage() {}, 'sendMessage');
+      window.chrome.runtime = {
+        id: undefined,
+        connect,
+        sendMessage,
+        onMessage: listener(),
+        onConnect: listener(),
+      };
+    }
+    if (!window.chrome.csi) {
+      window.chrome.csi = mark(function csi() {
+        const timing = performance.timing || {};
+        return {
+          onloadT: timing.domContentLoadedEventEnd || Date.now(),
+          startE: timing.navigationStart || Date.now(),
+          pageT: Math.max(0, performance.now()),
+          tran: 15,
+        };
+      }, 'csi');
+    }
+    if (!window.chrome.loadTimes) {
+      window.chrome.loadTimes = mark(function loadTimes() {
+        const timing = performance.timing || {};
+        const navigation = performance.getEntriesByType('navigation')[0];
+        return {
+          requestTime: (timing.navigationStart || Date.now()) / 1000,
+          startLoadTime: (timing.navigationStart || Date.now()) / 1000,
+          commitLoadTime: (timing.responseStart || Date.now()) / 1000,
+          finishDocumentLoadTime: (timing.domContentLoadedEventEnd || Date.now()) / 1000,
+          finishLoadTime: (timing.loadEventEnd || Date.now()) / 1000,
+          firstPaintTime: (timing.responseStart || Date.now()) / 1000,
+          firstPaintAfterLoadTime: 0,
+          navigationType: 'Other',
+          wasFetchedViaSpdy: !!(navigation && /^h2|h3$/.test(navigation.nextHopProtocol)),
+          wasNpnNegotiated: true,
+          npnNegotiatedProtocol: navigation ? navigation.nextHopProtocol : 'h2',
+          wasAlternateProtocolAvailable: false,
+          connectionInfo: navigation ? navigation.nextHopProtocol : 'h2',
+        };
+      }, 'loadTimes');
     }
   } catch (_) {}
 

--- a/crates/ab-mcp/src/main.rs
+++ b/crates/ab-mcp/src/main.rs
@@ -715,11 +715,11 @@ struct DragArgs {
     target_selector: Option<String>,
 }
 
-/// Build the browser per environment. Default: headful, real profile, no JS
-/// patching (fingerprint == a real human Chrome). Overrides:
+/// Build the browser per environment. Default: headful, real profile, and the
+/// self-guarding JS stealth layer. Overrides:
 ///   AB_CONNECT=<port>  attach to a Chrome the user already launched (strongest)
-///   AB_HEADLESS=1      run headless (a tell; enable AB_STEALTH to compensate)
-///   AB_STEALTH=1       inject the JS stealth-patch fallback (headless only)
+///   AB_HEADLESS=1      run headless (a strong fingerprint tell)
+///   AB_NO_STEALTH=1    disable stealth injection for launched browsers
 ///   AB_PROFILE=<dir>   persistent profile location
 async fn make_browser() -> ab_browser::Result<Browser> {
     if let Ok(port) = std::env::var("AB_CONNECT") {
@@ -727,7 +727,7 @@ async fn make_browser() -> ab_browser::Result<Browser> {
     }
     Browser::launch(LaunchOptions {
         headless: std::env::var("AB_HEADLESS").is_ok(),
-        inject_stealth: std::env::var("AB_STEALTH").is_ok(),
+        inject_stealth: std::env::var("AB_NO_STEALTH").is_err(),
         ..Default::default()
     })
     .await
@@ -2212,13 +2212,15 @@ impl BrowserServer {
         let mode = if std::env::var("AB_CONNECT").is_ok() {
             "connect"
         } else if std::env::var("AB_HEADLESS").is_ok() {
-            if std::env::var("AB_STEALTH").is_ok() {
-                "headless+stealth"
+            if std::env::var("AB_NO_STEALTH").is_ok() {
+                "headless (stealth disabled)"
             } else {
-                "headless"
+                "headless+stealth"
             }
+        } else if std::env::var("AB_NO_STEALTH").is_ok() {
+            "headful (stealth disabled)"
         } else {
-            "headful (be-real)"
+            "headful+stealth"
         };
         let detectable_diagnostics = if self.allow_detectable_tools {
             "allowed (explicit opt-in)"
@@ -2586,15 +2588,48 @@ impl BrowserServer {
         Parameters(a): Parameters<PageArg>,
     ) -> Result<CallToolResult, McpError> {
         let page = self.page_of(&a.page).await?;
-        let js = r#"JSON.stringify({
-            webdriver: navigator.webdriver === undefined ? 'undefined' : String(navigator.webdriver),
-            plugins: navigator.plugins.length,
-            languages: (navigator.languages || []).join(','),
-            hasChrome: !!window.chrome,
-            hasChromeRuntime: !!(window.chrome && window.chrome.runtime),
-            headlessUA: /headless/i.test(navigator.userAgent),
-            userAgent: navigator.userAgent
-        })"#;
+        let js = r#"(async () => {
+            let webglVendor = '';
+            let webglRenderer = '';
+            try {
+                const canvas = document.createElement('canvas');
+                const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+                const ext = gl && gl.getExtension('WEBGL_debug_renderer_info');
+                if (gl && ext) {
+                    webglVendor = String(gl.getParameter(ext.UNMASKED_VENDOR_WEBGL) || '');
+                    webglRenderer = String(gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) || '');
+                }
+            } catch (_) {}
+            let notificationPermission = 'unavailable';
+            let notificationQuery = 'unavailable';
+            try {
+                notificationPermission = Notification.permission;
+                notificationQuery = (await navigator.permissions.query({ name: 'notifications' })).state;
+            } catch (_) {}
+            return JSON.stringify({
+                webdriver: navigator.webdriver === undefined ? 'undefined' : String(navigator.webdriver),
+                plugins: navigator.plugins.length,
+                languages: (navigator.languages || []).join(','),
+                hasChrome: !!window.chrome,
+                hasChromeRuntime: !!(window.chrome && window.chrome.runtime),
+                headlessUA: /headless/i.test(navigator.userAgent),
+                userAgent: navigator.userAgent,
+                webglVendor,
+                webglRenderer,
+                softwareWebgl: /swiftshader|llvmpipe|software|mesa/i.test(webglVendor + ' ' + webglRenderer),
+                voices: speechSynthesis ? speechSynthesis.getVoices().length : 0,
+                notificationPermission,
+                notificationQuery,
+                outerWidth: window.outerWidth,
+                outerHeight: window.outerHeight,
+                screenWidth: screen.width,
+                screenHeight: screen.height,
+                screenAvailWidth: screen.availWidth,
+                screenAvailHeight: screen.availHeight,
+                innerWidth: window.innerWidth,
+                innerHeight: window.innerHeight
+            });
+        })()"#;
         let raw = page.evaluate(js).await.map_err(fail)?;
         let s = raw.as_str().unwrap_or("{}");
         let v: serde_json::Value = serde_json::from_str(s).unwrap_or(serde_json::Value::Null);
@@ -2619,8 +2654,60 @@ impl BrowserServer {
             get("hasChrome").as_bool().unwrap_or(false),
             "window.chrome present".into(),
         ));
+        checks.push((
+            get("hasChromeRuntime").as_bool().unwrap_or(false),
+            "chrome.runtime present".into(),
+        ));
         let headless = get("headlessUA").as_bool().unwrap_or(false);
         checks.push((!headless, format!("headless in UA = {headless}")));
+        let webgl_vendor = get("webglVendor").as_str().unwrap_or("").to_string();
+        let webgl_renderer = get("webglRenderer").as_str().unwrap_or("").to_string();
+        let software_webgl = get("softwareWebgl").as_bool().unwrap_or(true);
+        checks.push((
+            !webgl_renderer.is_empty() && !software_webgl,
+            format!("WebGL = {webgl_vendor} / {webgl_renderer}"),
+        ));
+        let voices = get("voices").as_u64().unwrap_or(0);
+        checks.push((voices > 0, format!("speechSynthesis voices = {voices}")));
+        let notification_permission = get("notificationPermission")
+            .as_str()
+            .unwrap_or("unavailable")
+            .to_string();
+        let notification_query = get("notificationQuery")
+            .as_str()
+            .unwrap_or("unavailable")
+            .to_string();
+        checks.push((
+            notification_permission != "unavailable"
+                && notification_permission == notification_query,
+            format!(
+                "Notification.permission/query = {notification_permission}/{notification_query}"
+            ),
+        ));
+        let outer_width = get("outerWidth").as_u64().unwrap_or(0);
+        let outer_height = get("outerHeight").as_u64().unwrap_or(0);
+        checks.push((
+            outer_width > 0 && outer_height > 0,
+            format!("outer size = {outer_width}x{outer_height}"),
+        ));
+        let screen_width = get("screenWidth").as_u64().unwrap_or(0);
+        let screen_height = get("screenHeight").as_u64().unwrap_or(0);
+        let avail_width = get("screenAvailWidth").as_u64().unwrap_or(0);
+        let avail_height = get("screenAvailHeight").as_u64().unwrap_or(0);
+        let inner_width = get("innerWidth").as_u64().unwrap_or(0);
+        let inner_height = get("innerHeight").as_u64().unwrap_or(0);
+        let sane_screen = screen_width >= inner_width
+            && screen_height >= inner_height
+            && avail_width > 0
+            && avail_height > 0
+            && avail_width <= screen_width
+            && avail_height <= screen_height;
+        checks.push((
+            sane_screen,
+            format!(
+                "screen/available/inner = {screen_width}x{screen_height} / {avail_width}x{avail_height} / {inner_width}x{inner_height}"
+            ),
+        ));
 
         let mut passed = 0;
         for (good, label) in &checks {
@@ -2632,6 +2719,9 @@ impl BrowserServer {
             }
         }
         report.push_str(&format!("\nscore: {passed}/{} passed", checks.len()));
+        report.push_str(
+            "\nlimited probe: does not cover input-layer code/keyCode, canvas/audio, TLS/JA3, or CDP tells",
+        );
         Ok(ok(report))
     }
 }
@@ -2801,14 +2891,14 @@ Options:\n\
   --port <port>            Enable HTTP mode on this port\n\
   --user-data-dir <path>   Persistent browser profile directory\n\
   --headless / --headed    Run headless or headful (default headful)\n\
-  --stealth                Inject the JS stealth-patch layer (for headless)\n\
+  --stealth                Compatibility no-op (stealth is enabled by default)\n\
   --allow-detectable-tools Allow main-world JS and Runtime-enabled console capture\n\
   --connect <port|url>     Attach to a Chrome already running with\n\
                            --remote-debugging-port (identical fingerprint)\n\
   -h, --help               Show this help\n\
   -V, --version            Show the browser-rs version\n\
 \n\
-Env equivalents: AB_HTTP, AB_HTTP_CAPABILITY, AB_PROFILE, AB_HEADLESS, AB_STEALTH, AB_CONNECT, AB_CHROME, AB_ALLOW_DETECTABLE_TOOLS.\n";
+Env equivalents: AB_HTTP, AB_HTTP_CAPABILITY, AB_PROFILE, AB_HEADLESS, AB_NO_STEALTH, AB_CONNECT, AB_CHROME, AB_ALLOW_DETECTABLE_TOOLS.\n";
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary
- Character key events (`Input.dispatchKeyEvent`) now carry a real US-QWERTY `code`/`windowsVirtualKeyCode`/`nativeVirtualKeyCode`, closing the `KeyboardEvent.code === ""` / `keyCode === 0` automation tell in the typing and single-key-press paths.
- Long (>=30 char) input now emulates a human Ctrl/Cmd+V paste gesture (trusted modifier+V key events around the text delivery) instead of a bare, keyless `Input.insertText`; still cancellable via the existing `CancellationToken`.
- The JS stealth-patch layer (`STEALTH_INIT_SCRIPT`) now injects by default for **both** headful and headless launched browsers (it is self-guarding — WebGL/voices/outer-size patches only fire when the real value is already wrong). Opt out with `AB_NO_STEALTH=1`. `AB_CONNECT` (attach to the user's real browser) stays untouched.
- More realistic `chrome.runtime`/`chrome.csi`/`chrome.loadTimes` shim (native-looking functions via the existing `mark()` toString hardening) instead of a bare `{}`.
- `browser_fingerprint_check` now also reports WebGL renderer, speech-voice count, `window.chrome` presence, notification-permission consistency, and viewport sanity — with an explicit note that it doesn't cover input-layer/canvas/audio/TLS tells.
- Fixed a `Page.createIsolatedWorld` param typo (`grantUniveralAccess` -> `grantUniversalAccess`).
- Version bump 0.2.0 -> 0.2.1.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --release --workspace`
- [x] `cargo test --workspace` (all passing)
- [x] `node bench/run.mjs target/release/browser-rs` — stealth benchmark hard gate: **13/13 — looks human**
- [ ] CI (fmt/clippy/build/test/bench) green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)