### PR TITLE
v0.2.2: closed-shadow/iframe hit-testing, real clipboard, chrome.runtime fidelity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ab-browser"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "ab-cdp",
  "anyhow",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "ab-cdp"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "futures-util",
  "serde",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "ab-mcp"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "ab-browser",
  "ab-cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/ab-cdp", "crates/ab-browser", "crates/ab-mcp"]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,7 +22,7 @@ browser-rs --help
 
 ```bash
 # Pin a specific version
-curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | AB_VERSION=v0.2.1 sh
+curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | AB_VERSION=v0.2.2 sh
 
 # Choose the install directory
 AB_BIN_DIR=~/bin curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | sh

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 browser-rs is a lightweight, stealth-oriented browser MCP server. It lets
 multiple AI agents share one logged-in Chrome — each agent controls only its
 own tabs — for parallel scraping, web automation, and QA without every agent
-spinning up its own browser. 67 Playwright-style tools, one Rust binary, no
+spinning up its own browser. 68 Playwright-style tools, one Rust binary, no
 Node.js runtime.
 
 ```mermaid
@@ -389,11 +389,11 @@ allowlist and cannot override strict mode.
 
 ## Tools
 
-MCP implements 67 `browser_*` tools; strict mode advertises 66 by default:
+MCP implements 68 `browser_*` tools; strict mode advertises 67 by default:
 
 **Navigation and inspection:** `browser_navigate` · `browser_new_page` · `browser_snapshot` · `browser_activate_page` · `browser_read` · `browser_get_visible_html` · `browser_get_visible_text` · `browser_find` · `browser_take_screenshot` · `browser_save_pdf` · `browser_pages` · `browser_tabs` · `browser_switch_page` · `browser_profile` · `browser_status`
 
-**Interaction:** `browser_click` · `browser_pointer` · `browser_wheel` · `browser_type` · `browser_cancel_typing` · `browser_press_key` · `browser_hover` · `browser_select_option` · `browser_fill_form` · `browser_drag` · `browser_file_upload` · `browser_navigate_back` · `browser_wait_for` · `browser_resize` · `browser_evaluate` · `browser_run_code_unsafe` · `browser_iframe_click` · `browser_iframe_type` · `browser_iframe_read` · `browser_close_page` · `browser_close`
+**Interaction:** `browser_click` · `browser_pointer` · `browser_wheel` · `browser_type` · `browser_cancel_typing` · `browser_press_key` · `browser_hover` · `browser_select_option` · `browser_fill_form` · `browser_drag` · `browser_file_upload` · `browser_navigate_back` · `browser_wait_for` · `browser_resize` · `browser_evaluate` · `browser_run_code_unsafe` · `browser_iframe_click` · `browser_iframe_hover` · `browser_iframe_type` · `browser_iframe_read` · `browser_close_page` · `browser_close`
 
 Use `browser_activate_page({ "page": "p5" })` before automating a background
 tab whose site throttles lazy loading. It calls CDP `Target.activateTarget`,
@@ -407,8 +407,10 @@ v0.2 has no synthetic `input_route`.
 atomic insertion for paste/IME-like text of 30 characters or more.
 `browser_iframe_type` applies the same input behavior after focusing the target
 inside a nested iframe chain and routes OOPIF input through that frame's CDP
-session. `browser_iframe_click` similarly uses trusted pointer input, while
-`browser_select_option` performs native select type-ahead with trusted keys.
+session. `browser_iframe_click` and `browser_iframe_hover` use trusted pointer
+input and resolve selectors through open or closed shadow roots inside the
+target frame. `browser_select_option` performs native select type-ahead with
+trusted keys.
 `browser_cancel_typing` stops active typing started with `wait: false`; text
 already entered remains.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ browser-rs --help
 To pin this release instead of following `latest`:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | AB_VERSION=v0.2.1 sh
+curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | AB_VERSION=v0.2.2 sh
 ```
 
 **2. Run** — use stdio for a client that launches the server:
@@ -90,7 +90,28 @@ cargo install --git https://github.com/maestrojeong/browser-rs-mcp ab-mcp
 Set `AB_CHROME` if Chrome is not in a standard location.
 
 <details>
-<summary><strong>What's new (v0.1.14 - v0.2.1)</strong></summary>
+<summary><strong>What's new (v0.1.14 - v0.2.2)</strong></summary>
+
+**v0.2.2 — closed-shadow/iframe hit-testing, real clipboard, chrome.runtime
+fidelity.** Actionability hit-testing (used before every ref-based click) is
+now Runtime-free and pierces closed shadow roots — including inside iframes —
+via `Page.getLayoutMetrics` + `DOM.getNodeForLocation` +
+`Accessibility.getPartialAXTree`, instead of a main-world
+`document.elementFromPoint` call that always failed for closed-shadow targets.
+The same target is re-verified immediately before every `mousePressed` (not
+just once before the human-like travel), so a hover-menu closing mid-move
+fails loudly instead of silently pressing the wrong element.
+`browser_iframe_click` gained the same closed-shadow-piercing resolution, and
+a new `browser_iframe_hover` tool lets a hover-to-reveal menu inside an
+iframe open without any manual coordinate math. Modifier-combo key dispatch
+(`Meta+c`, `Ctrl+v`, …) now attaches the matching `Input.dispatchKeyEvent`
+`commands` (Copy/Paste/Cut/SelectAll) — CDP-synthesized key events bypass
+Chrome's native UI accelerator table, so Copy/Paste never reached the real OS
+clipboard without this. The `chrome.runtime` shim gained the six frozen
+extension-API enums (`OnInstalledReason`, `OnRestartRequiredReason`,
+`PlatformArch`, `PlatformNaclArch`, `PlatformOs`, `RequestUpdateCheckStatus`)
+real Chrome exposes even with no extension installed — their total absence
+was previously the single biggest passive-fingerprint tell.
 
 **v0.2.1 — input-layer and stealth hardening.** Character key events now carry
 a real US-QWERTY `code`/`windowsVirtualKeyCode`/`nativeVirtualKeyCode` alongside

--- a/crates/ab-browser/src/lib.rs
+++ b/crates/ab-browser/src/lib.rs
@@ -2433,21 +2433,11 @@ impl Page {
     }
 
     async fn press_key_on(&self, session_id: &str, key: &str) -> Result<()> {
-        let (event_key, code, vk) = match key {
-            "Enter" => (key, "Enter", 13),
-            "Tab" => (key, "Tab", 9),
-            "Escape" => (key, "Escape", 27),
-            "Backspace" => (key, "Backspace", 8),
-            "ArrowDown" => (key, "ArrowDown", 40),
-            "ArrowUp" => (key, "ArrowUp", 38),
-            "Home" => (key, "Home", 36),
-            "End" => (key, "End", 35),
-            _ if key.chars().count() == 1 => {
-                let (code, vk) = us_qwerty_key(key.chars().next().unwrap());
-                (key, code, vk)
-            }
-            _ => (key, "", 0),
-        };
+        if let Some(combo) = parse_key_combo(key)? {
+            return self.dispatch_key_combo(session_id, combo).await;
+        }
+
+        let (event_key, code, vk) = key_definition(key);
         self.client
             .send_on(
                 session_id,
@@ -2475,6 +2465,80 @@ impl Page {
                 }),
             )
             .await?;
+        tokio::time::sleep(Duration::from_millis(rand_u64(45, 140))).await;
+        Ok(())
+    }
+
+    async fn dispatch_key_combo(&self, session_id: &str, combo: KeyCombo<'_>) -> Result<()> {
+        let mut modifiers = 0;
+        for modifier in &combo.modifiers {
+            modifiers |= modifier.mask();
+            self.client
+                .send_on(
+                    session_id,
+                    "Input.dispatchKeyEvent",
+                    json!({
+                        "type": "rawKeyDown",
+                        "key": modifier.key(),
+                        "code": modifier.code(),
+                        "windowsVirtualKeyCode": modifier.windows_vk(),
+                        "modifiers": modifiers,
+                    }),
+                )
+                .await?;
+        }
+
+        let (event_key, code, vk) = key_definition(combo.key);
+        // CDP key events bypass Chrome's native UI accelerator routing. Attach
+        // the matching editor command so Copy/Paste reaches the OS clipboard.
+        let commands = shortcut_command(&combo.modifiers, combo.key)
+            .into_iter()
+            .collect::<Vec<_>>();
+        self.client
+            .send_on(
+                session_id,
+                "Input.dispatchKeyEvent",
+                json!({
+                    "type": "rawKeyDown",
+                    "key": event_key,
+                    "code": code,
+                    "windowsVirtualKeyCode": vk,
+                    "modifiers": modifiers,
+                    "commands": commands,
+                }),
+            )
+            .await?;
+        tokio::time::sleep(Duration::from_millis(rand_u64(25, 95))).await;
+        self.client
+            .send_on(
+                session_id,
+                "Input.dispatchKeyEvent",
+                json!({
+                    "type": "keyUp",
+                    "key": event_key,
+                    "code": code,
+                    "windowsVirtualKeyCode": vk,
+                    "modifiers": modifiers,
+                }),
+            )
+            .await?;
+
+        for modifier in combo.modifiers.iter().rev() {
+            modifiers &= !modifier.mask();
+            self.client
+                .send_on(
+                    session_id,
+                    "Input.dispatchKeyEvent",
+                    json!({
+                        "type": "keyUp",
+                        "key": modifier.key(),
+                        "code": modifier.code(),
+                        "windowsVirtualKeyCode": modifier.windows_vk(),
+                        "modifiers": modifiers,
+                    }),
+                )
+                .await?;
+        }
         tokio::time::sleep(Duration::from_millis(rand_u64(45, 140))).await;
         Ok(())
     }
@@ -3324,6 +3388,137 @@ fn needs_shift(ch: char) -> bool {
     ch.is_ascii_uppercase() || "~!@#$%^&*()_+{}|:\"<>?".contains(ch)
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum KeyModifier {
+    Alt,
+    Control,
+    Meta,
+    Shift,
+}
+
+impl KeyModifier {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "Alt" | "Option" => Some(Self::Alt),
+            "Control" | "Ctrl" => Some(Self::Control),
+            "Meta" | "Cmd" | "Command" => Some(Self::Meta),
+            "Shift" => Some(Self::Shift),
+            _ => None,
+        }
+    }
+
+    fn key(self) -> &'static str {
+        match self {
+            Self::Alt => "Alt",
+            Self::Control => "Control",
+            Self::Meta => "Meta",
+            Self::Shift => "Shift",
+        }
+    }
+
+    fn code(self) -> &'static str {
+        match self {
+            Self::Alt => "AltLeft",
+            Self::Control => "ControlLeft",
+            Self::Meta => "MetaLeft",
+            Self::Shift => "ShiftLeft",
+        }
+    }
+
+    fn windows_vk(self) -> u32 {
+        match self {
+            Self::Alt => 18,
+            Self::Control => 17,
+            Self::Meta => 91,
+            Self::Shift => 16,
+        }
+    }
+
+    fn mask(self) -> u32 {
+        match self {
+            Self::Alt => 1,
+            Self::Control => 2,
+            Self::Meta => 4,
+            Self::Shift => 8,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct KeyCombo<'a> {
+    modifiers: Vec<KeyModifier>,
+    key: &'a str,
+}
+
+fn parse_key_combo(key: &str) -> Result<Option<KeyCombo<'_>>> {
+    if !key.contains('+') {
+        return Ok(None);
+    }
+
+    let mut parts = key.split('+').collect::<Vec<_>>();
+    let event_key = parts
+        .pop()
+        .filter(|part| !part.is_empty())
+        .ok_or_else(|| BrowserError::Protocol(format!("invalid key combo: {key}")))?;
+    let mut modifiers = Vec::with_capacity(parts.len());
+    for part in parts {
+        let modifier = KeyModifier::parse(part)
+            .ok_or_else(|| BrowserError::Protocol(format!("unknown key modifier: {part}")))?;
+        if modifiers.contains(&modifier) {
+            return Err(BrowserError::Protocol(format!(
+                "duplicate key modifier: {part}"
+            )));
+        }
+        modifiers.push(modifier);
+    }
+    if modifiers.is_empty() {
+        return Err(BrowserError::Protocol(format!("invalid key combo: {key}")));
+    }
+    Ok(Some(KeyCombo {
+        modifiers,
+        key: event_key,
+    }))
+}
+
+fn key_definition(key: &str) -> (&str, &'static str, u32) {
+    match key {
+        "Enter" => (key, "Enter", 13),
+        "Tab" => (key, "Tab", 9),
+        "Escape" => (key, "Escape", 27),
+        "Backspace" => (key, "Backspace", 8),
+        "Delete" => (key, "Delete", 46),
+        "ArrowDown" => (key, "ArrowDown", 40),
+        "ArrowUp" => (key, "ArrowUp", 38),
+        "ArrowLeft" => (key, "ArrowLeft", 37),
+        "ArrowRight" => (key, "ArrowRight", 39),
+        "Home" => (key, "Home", 36),
+        "End" => (key, "End", 35),
+        _ if key.chars().count() == 1 => {
+            let (code, vk) = us_qwerty_key(key.chars().next().expect("one character checked"));
+            (key, code, vk)
+        }
+        _ => (key, "", 0),
+    }
+}
+
+fn shortcut_command(modifiers: &[KeyModifier], key: &str) -> Option<&'static str> {
+    #[cfg(target_os = "macos")]
+    let primary = KeyModifier::Meta;
+    #[cfg(not(target_os = "macos"))]
+    let primary = KeyModifier::Control;
+
+    if modifiers != [primary] {
+        return None;
+    }
+    match key.to_ascii_lowercase().as_str() {
+        "a" => Some("SelectAll"),
+        "c" => Some("Copy"),
+        "v" => Some("Paste"),
+        "x" => Some("Cut"),
+        _ => None,
+    }
+}
+
 fn us_qwerty_key(ch: char) -> (&'static str, u32) {
     match ch {
         'a' | 'A' => ("KeyA", 65),
@@ -3493,8 +3688,9 @@ async fn discover_ws_url(port: u16) -> Result<String> {
 mod tests {
     use super::{
         activation_verified, ax_hit_has_backend_ancestor, build_descend_js, build_frame_element_js,
-        collect_piercing_query_roots, require_frame_chain, resolve_frame_id, split_frame_chain,
-        us_qwerty_key, uses_insert_text, FrameAction, ReadMode,
+        collect_piercing_query_roots, parse_key_combo, require_frame_chain, resolve_frame_id,
+        shortcut_command, split_frame_chain, us_qwerty_key, uses_insert_text, FrameAction,
+        KeyCombo, KeyModifier, ReadMode,
     };
     use serde_json::json;
 
@@ -3513,6 +3709,46 @@ mod tests {
         assert_eq!(us_qwerty_key('!'), ("Digit1", 49));
         assert_eq!(us_qwerty_key('?'), ("Slash", 191));
         assert_eq!(us_qwerty_key('한'), ("", 0));
+    }
+
+    #[test]
+    fn key_combo_parser_maps_aliases_and_cdp_modifier_bits() {
+        assert_eq!(
+            parse_key_combo("Meta+c").unwrap(),
+            Some(KeyCombo {
+                modifiers: vec![KeyModifier::Meta],
+                key: "c",
+            })
+        );
+        assert_eq!(
+            parse_key_combo("Control+Shift+v").unwrap(),
+            Some(KeyCombo {
+                modifiers: vec![KeyModifier::Control, KeyModifier::Shift],
+                key: "v",
+            })
+        );
+        assert_eq!(KeyModifier::Alt.mask(), 1);
+        assert_eq!(KeyModifier::Control.mask(), 2);
+        assert_eq!(KeyModifier::Meta.mask(), 4);
+        assert_eq!(KeyModifier::Shift.mask(), 8);
+        assert!(parse_key_combo("Enter").unwrap().is_none());
+        assert!(parse_key_combo("Meta+").is_err());
+        assert!(parse_key_combo("Hyper+c").is_err());
+    }
+
+    #[test]
+    fn primary_clipboard_shortcuts_map_to_cdp_editor_commands() {
+        #[cfg(target_os = "macos")]
+        let primary = KeyModifier::Meta;
+        #[cfg(not(target_os = "macos"))]
+        let primary = KeyModifier::Control;
+
+        assert_eq!(shortcut_command(&[primary], "a"), Some("SelectAll"));
+        assert_eq!(shortcut_command(&[primary], "c"), Some("Copy"));
+        assert_eq!(shortcut_command(&[primary], "v"), Some("Paste"));
+        assert_eq!(shortcut_command(&[primary], "x"), Some("Cut"));
+        assert_eq!(shortcut_command(&[primary], "q"), None);
+        assert_eq!(shortcut_command(&[primary, KeyModifier::Shift], "v"), None);
     }
 
     #[test]

--- a/crates/ab-browser/src/lib.rs
+++ b/crates/ab-browser/src/lib.rs
@@ -387,7 +387,6 @@ pub enum ReadMode {
 /// Action to perform on the element resolved at the bottom of an iframe chain
 /// (see `Page::descend_and_act`).
 enum FrameAction {
-    Point,
     Focus { clear: bool },
     Read(ReadMode),
 }
@@ -443,7 +442,6 @@ fn build_descend_js(chain: &[&str], selector: &str, action: &FrameAction) -> Str
     let chain_json = serde_json::to_string(chain).unwrap_or_else(|_| "[]".into());
     let sel_json = serde_json::to_string(selector).unwrap_or_else(|_| "\"\"".into());
     let act_js = match action {
-        FrameAction::Point => "el.scrollIntoView({block:'center',inline:'center'}); const r=el.getBoundingClientRect(); if(r.width<=0||r.height<=0) throw new Error('element has no visible box'); return {ok:true,x:offsetX+r.left+r.width/2,y:offsetY+r.top+r.height/2,halfWidth:r.width/2,halfHeight:r.height/2};".to_string(),
         FrameAction::Focus { clear } => {
             let select_js = if *clear {
                 " if (typeof el.select === 'function') el.select(); else if (typeof el.setSelectionRange === 'function') el.setSelectionRange(0, (el.value || '').length);"
@@ -458,26 +456,17 @@ fn build_descend_js(chain: &[&str], selector: &str, action: &FrameAction) -> Str
                 .to_string()
         }
     };
-    let locate = matches!(action, FrameAction::Point);
     format!(
         r#"(() => {{
   const chain = {chain_json};
-  const locate = {locate};
   let doc = document;
-  let offsetX = 0, offsetY = 0;
   for (let i = 0; i < chain.length; i++) {{
     const f = doc.querySelector(chain[i]);
     if (!f) throw new Error('iframe not found at step ' + i + ': ' + chain[i]);
-    if (locate) {{
-      f.scrollIntoView({{block:'center',inline:'center'}});
-      const r = f.getBoundingClientRect();
-      offsetX += r.left + (f.clientLeft || 0);
-      offsetY += r.top + (f.clientTop || 0);
-    }}
     let inner = null;
     try {{ inner = f.contentDocument; }} catch (e) {{ inner = null; }}
     if (!inner) {{
-      return {{ ok: false, index: i, src: f.src || f.getAttribute('src') || '', name: f.name || f.getAttribute('name') || '', offsetX, offsetY }};
+      return {{ ok: false, index: i, src: f.src || f.getAttribute('src') || '', name: f.name || f.getAttribute('name') || '' }};
     }}
     doc = inner;
   }}
@@ -485,7 +474,6 @@ fn build_descend_js(chain: &[&str], selector: &str, action: &FrameAction) -> Str
   if (!el) throw new Error('element not found: ' + {sel_json});
   {act_js}
 }})()"#,
-        locate = locate,
     )
 }
 
@@ -637,6 +625,13 @@ pub struct Page {
 struct FrameExecutionContext {
     session_id: String,
     context_id: i64,
+}
+
+#[derive(Clone, Debug)]
+struct FramePointerTarget {
+    session_id: String,
+    root_point: (f64, f64),
+    frame_point: (f64, f64),
 }
 
 impl Page {
@@ -1043,6 +1038,24 @@ fn ax_hit_has_backend_ancestor(nodes: &[Value], hit_backend: i64, target_backend
             .find(|candidate| candidate.get("nodeId").and_then(Value::as_str) == Some(parent_id));
     }
     false
+}
+
+fn collect_piercing_query_roots(node: &Value, include_node: bool, out: &mut Vec<i64>) {
+    if include_node {
+        if let Some(backend) = node.get("backendNodeId").and_then(Value::as_i64) {
+            out.push(backend);
+        }
+    }
+    if let Some(shadow_roots) = node.get("shadowRoots").and_then(Value::as_array) {
+        for shadow_root in shadow_roots {
+            collect_piercing_query_roots(shadow_root, true, out);
+        }
+    }
+    if let Some(children) = node.get("children").and_then(Value::as_array) {
+        for child in children {
+            collect_piercing_query_roots(child, false, out);
+        }
+    }
 }
 
 /// Actions driven by an accessibility `[ref]` (its backendDOMNodeId).
@@ -1632,55 +1645,303 @@ impl Page {
     /// Click an element inside an iframe with trusted browser-generated pointer
     /// input. `frame_selector` may chain multiple
     /// CSS selectors with `>>` to descend through nested iframes (e.g.
-    /// `"iframe.wrapper >> iframe.popup"`). Same-origin frames are resolved
-    /// with isolated-world DOM access; if a cross-origin boundary is
-    /// hit, resolution automatically falls back to CDP (`Page.getFrameTree` +
-    /// `Page.createIsolatedWorld`), which is not subject to the Same-Origin
-    /// Policy. The resolved element box is translated into top-level viewport
-    /// coordinates before CDP mouse press/release events are dispatched.
+    /// `"iframe.wrapper >> iframe.popup"`). Each frame is entered through an
+    /// isolated CDP execution context, including OOPIF targets. The final CSS
+    /// selector is queried against the document and every CDP-exposed shadow
+    /// root, so open and closed shadow trees are supported. The resolved box is
+    /// translated into top-level viewport coordinates before trusted input is
+    /// dispatched.
     pub async fn iframe_click(&self, frame_selector: &str, selector: &str) -> Result<()> {
         let chain = require_frame_chain(frame_selector)?;
-        // The first pass brings every frame and the target into view. A deep
-        // target scroll can move an ancestor browsing context, so resolve once
-        // more after scrolling and dispatch only from the stable coordinates.
-        self.descend_and_act_with_session(&chain, selector, &FrameAction::Point)
+        let target = self.iframe_pointer_target(&chain, selector).await?;
+        if target.session_id == self.session_id {
+            self.trusted_click_at(target.root_point.0, target.root_point.1)
+                .await
+        } else {
+            self.trusted_frame_click_at(&target.session_id, target.root_point, target.frame_point)
+                .await
+        }
+    }
+
+    /// Hover an element inside an iframe with trusted browser-generated pointer
+    /// input. Selector resolution pierces open and closed shadow roots through
+    /// CDP, matching [`iframe_click`](Self::iframe_click).
+    pub async fn iframe_hover(&self, frame_selector: &str, selector: &str) -> Result<()> {
+        let chain = require_frame_chain(frame_selector)?;
+        let target = self.iframe_pointer_target(&chain, selector).await?;
+        self.trusted_frame_hover_at(&target.session_id, target.root_point, target.frame_point)
+            .await
+    }
+
+    async fn iframe_pointer_target(
+        &self,
+        chain: &[&str],
+        selector: &str,
+    ) -> Result<FramePointerTarget> {
+        // A target scroll can move an ancestor browsing context. Resolve and
+        // scroll once, then repeat the full chain before using coordinates.
+        let (context, _) = self.resolve_frame_chain_for_pointer(chain).await?;
+        self.frame_selector_point(&context, selector).await?;
+        let (context, root_offset) = self.resolve_frame_chain_for_pointer(chain).await?;
+        let (frame_point, half_size) = self.frame_selector_point(&context, selector).await?;
+        let frame_point = (
+            frame_point.0 + off_center(half_size.0),
+            frame_point.1 + off_center(half_size.1),
+        );
+        Ok(FramePointerTarget {
+            session_id: context.session_id,
+            root_point: (root_offset.0 + frame_point.0, root_offset.1 + frame_point.1),
+            frame_point,
+        })
+    }
+
+    async fn resolve_frame_chain_for_pointer(
+        &self,
+        chain: &[&str],
+    ) -> Result<(FrameExecutionContext, (f64, f64))> {
+        let mut context: Option<FrameExecutionContext> = None;
+        let mut root_offset = (0.0, 0.0);
+        for selector in chain {
+            let js = build_frame_element_js(&[selector], 0);
+            let remote = self.eval_remote(&js, context.as_ref()).await?;
+            let result = remote
+                .get("result")
+                .ok_or_else(|| BrowserError::Protocol("iframe query returned no result".into()))?;
+            let object_id = result
+                .get("objectId")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    BrowserError::Protocol(format!(
+                        "iframe element `{selector}` did not return a remote object"
+                    ))
+                })?;
+            let session_id = context
+                .as_ref()
+                .map(|value| value.session_id.as_str())
+                .unwrap_or(&self.session_id);
+            let rect = self
+                .client
+                .send_on(
+                    session_id,
+                    "Runtime.callFunctionOn",
+                    json!({
+                        "objectId": object_id,
+                        "functionDeclaration": "function() { this.scrollIntoView({block:'center',inline:'center'}); const r=this.getBoundingClientRect(); return {x:r.left+(this.clientLeft||0),y:r.top+(this.clientTop||0)}; }",
+                        "returnByValue": true,
+                    }),
+                )
+                .await?;
+            let desc = self
+                .client
+                .send_on(
+                    session_id,
+                    "DOM.describeNode",
+                    json!({ "objectId": object_id }),
+                )
+                .await;
+            let _ = self
+                .client
+                .send_on(
+                    session_id,
+                    "Runtime.releaseObject",
+                    json!({ "objectId": object_id }),
+                )
+                .await;
+            let rect = rect.pointer("/result/value").ok_or_else(|| {
+                BrowserError::Protocol(format!("iframe `{selector}` has no viewport box"))
+            })?;
+            root_offset.0 += rect.get("x").and_then(Value::as_f64).ok_or_else(|| {
+                BrowserError::Protocol(format!("iframe `{selector}` has no viewport x"))
+            })?;
+            root_offset.1 += rect.get("y").and_then(Value::as_f64).ok_or_else(|| {
+                BrowserError::Protocol(format!("iframe `{selector}` has no viewport y"))
+            })?;
+            let frame_id = desc?
+                .pointer("/node/frameId")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    BrowserError::Protocol(format!(
+                        "iframe element `{selector}` has no CDP frame id"
+                    ))
+                })?
+                .to_string();
+            context = Some(
+                self.create_isolated_world_for_frame(&frame_id, session_id)
+                    .await?,
+            );
+        }
+        context
+            .map(|value| (value, root_offset))
+            .ok_or_else(|| BrowserError::Protocol("iframe chain is empty".into()))
+    }
+
+    async fn frame_selector_point(
+        &self,
+        context: &FrameExecutionContext,
+        selector: &str,
+    ) -> Result<((f64, f64), (f64, f64))> {
+        let backend = self
+            .backend_for_piercing_selector(context, selector)
+            .await?
+            .ok_or_else(|| BrowserError::Protocol(format!("element not found: {selector}")))?;
+        self.client
+            .send_on(
+                &context.session_id,
+                "DOM.scrollIntoViewIfNeeded",
+                json!({ "backendNodeId": backend }),
+            )
             .await?;
-        let (point, session_id) = self
-            .descend_and_act_with_session(&chain, selector, &FrameAction::Point)
+        tokio::time::sleep(Duration::from_millis(rand_u64(30, 80))).await;
+        let resolved = self
+            .client
+            .send_on(
+                &context.session_id,
+                "DOM.resolveNode",
+                json!({
+                    "backendNodeId": backend,
+                    "executionContextId": context.context_id,
+                }),
+            )
             .await?;
-        let x = point
-            .get("x")
-            .and_then(Value::as_f64)
-            .ok_or_else(|| BrowserError::Protocol("iframe target has no viewport x".into()))?;
-        let y = point
-            .get("y")
-            .and_then(Value::as_f64)
-            .ok_or_else(|| BrowserError::Protocol("iframe target has no viewport y".into()))?;
-        let half_width = point
-            .get("halfWidth")
-            .and_then(Value::as_f64)
-            .unwrap_or(0.0);
-        let half_height = point
+        let object_id = resolved
+            .pointer("/object/objectId")
+            .and_then(Value::as_str)
+            .ok_or_else(|| BrowserError::Protocol("iframe target did not resolve".into()))?;
+        let rect = self
+            .client
+            .send_on(
+                &context.session_id,
+                "Runtime.callFunctionOn",
+                json!({
+                    "objectId": object_id,
+                    "functionDeclaration": "function() { const r=this.getBoundingClientRect(); return {x:r.left+r.width/2,y:r.top+r.height/2,halfWidth:r.width/2,halfHeight:r.height/2}; }",
+                    "returnByValue": true,
+                }),
+            )
+            .await;
+        let _ = self
+            .client
+            .send_on(
+                &context.session_id,
+                "Runtime.releaseObject",
+                json!({ "objectId": object_id }),
+            )
+            .await;
+        let rect = rect?
+            .pointer("/result/value")
+            .cloned()
+            .ok_or_else(|| BrowserError::Protocol("iframe target has no viewport box".into()))?;
+        let width = rect.get("halfWidth").and_then(Value::as_f64).unwrap_or(0.0);
+        let height = rect
             .get("halfHeight")
             .and_then(Value::as_f64)
             .unwrap_or(0.0);
-        let dx = off_center(half_width);
-        let dy = off_center(half_height);
-        let root_point = (x + dx, y + dy);
-        if session_id == self.session_id {
-            self.trusted_click_at(root_point.0, root_point.1).await
-        } else {
-            let local_x = point
-                .get("localX")
-                .and_then(Value::as_f64)
-                .ok_or_else(|| BrowserError::Protocol("iframe target has no local x".into()))?;
-            let local_y = point
-                .get("localY")
-                .and_then(Value::as_f64)
-                .ok_or_else(|| BrowserError::Protocol("iframe target has no local y".into()))?;
-            self.trusted_frame_click_at(&session_id, root_point, (local_x + dx, local_y + dy))
-                .await
+        if width <= 0.0 || height <= 0.0 {
+            return Err(BrowserError::Protocol(
+                "iframe target has no visible box".into(),
+            ));
         }
+        Ok((
+            (
+                rect.get("x").and_then(Value::as_f64).ok_or_else(|| {
+                    BrowserError::Protocol("iframe target has no viewport x".into())
+                })?,
+                rect.get("y").and_then(Value::as_f64).ok_or_else(|| {
+                    BrowserError::Protocol("iframe target has no viewport y".into())
+                })?,
+            ),
+            (width, height),
+        ))
+    }
+
+    async fn backend_for_piercing_selector(
+        &self,
+        context: &FrameExecutionContext,
+        selector: &str,
+    ) -> Result<Option<i64>> {
+        // Populate frontend node ids, then describe this frame's exact document
+        // with `pierce` so closed shadow roots are represented as query roots.
+        self.client
+            .send_on(
+                &context.session_id,
+                "DOM.getDocument",
+                json!({ "depth": 0, "pierce": true }),
+            )
+            .await?;
+        let remote = self.eval_remote("document", Some(context)).await?;
+        let object_id = remote
+            .pointer("/result/objectId")
+            .and_then(Value::as_str)
+            .ok_or_else(|| BrowserError::Protocol("frame document did not resolve".into()))?;
+        let described = self
+            .client
+            .send_on(
+                &context.session_id,
+                "DOM.describeNode",
+                json!({ "objectId": object_id, "depth": -1, "pierce": true }),
+            )
+            .await;
+        let _ = self
+            .client
+            .send_on(
+                &context.session_id,
+                "Runtime.releaseObject",
+                json!({ "objectId": object_id }),
+            )
+            .await;
+        let described = described?;
+        let root = described
+            .get("node")
+            .ok_or_else(|| BrowserError::Protocol("frame document has no DOM node".into()))?;
+        let mut root_backends = Vec::new();
+        collect_piercing_query_roots(root, true, &mut root_backends);
+        let pushed = self
+            .client
+            .send_on(
+                &context.session_id,
+                "DOM.pushNodesByBackendIdsToFrontend",
+                json!({ "backendNodeIds": root_backends }),
+            )
+            .await?;
+        let roots = pushed
+            .get("nodeIds")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_i64)
+            .filter(|node_id| *node_id != 0);
+        for node_id in roots {
+            let result = self
+                .client
+                .send_on(
+                    &context.session_id,
+                    "DOM.querySelector",
+                    json!({ "nodeId": node_id, "selector": selector }),
+                )
+                .await
+                .map_err(|error| {
+                    BrowserError::Protocol(format!(
+                        "failed to query iframe DOM root {node_id} for {selector:?}: {error}"
+                    ))
+                })?;
+            let Some(node_id) = result
+                .get("nodeId")
+                .and_then(Value::as_i64)
+                .filter(|value| *value != 0)
+            else {
+                continue;
+            };
+            let node = self
+                .client
+                .send_on(
+                    &context.session_id,
+                    "DOM.describeNode",
+                    json!({ "nodeId": node_id }),
+                )
+                .await?;
+            return Ok(node.pointer("/node/backendNodeId").and_then(Value::as_i64));
+        }
+        Ok(None)
     }
 
     /// Focus an input inside a same-origin, cross-origin, or OOPIF iframe and
@@ -1761,39 +2022,19 @@ impl Page {
     ) -> Result<(Value, String)> {
         let mut context: Option<FrameExecutionContext> = None;
         let mut remaining: Vec<&str> = chain.to_vec();
-        let mut root_offset_x = 0.0;
-        let mut root_offset_y = 0.0;
         // Bound the loop: at most one CDP hop per chain element, plus one.
         for _ in 0..=chain.len() {
             let js = build_descend_js(&remaining, selector, action);
-            let mut result = match context.as_ref() {
+            let result = match context.as_ref() {
                 None => self.evaluate(&js).await?,
                 Some(ctx) => self.eval_with_context(&js, ctx).await?,
             };
             if result.get("ok").and_then(Value::as_bool) == Some(true) {
-                if matches!(action, FrameAction::Point) {
-                    let local_x = result.get("x").and_then(Value::as_f64).ok_or_else(|| {
-                        BrowserError::Protocol("iframe point result has no x".into())
-                    })?;
-                    let local_y = result.get("y").and_then(Value::as_f64).ok_or_else(|| {
-                        BrowserError::Protocol("iframe point result has no y".into())
-                    })?;
-                    if let Some(object) = result.as_object_mut() {
-                        object.insert("localX".into(), json!(local_x));
-                        object.insert("localY".into(), json!(local_y));
-                        object.insert("x".into(), json!(root_offset_x + local_x));
-                        object.insert("y".into(), json!(root_offset_y + local_y));
-                    }
-                }
                 let session_id = context
                     .as_ref()
                     .map(|ctx| ctx.session_id.clone())
                     .unwrap_or_else(|| self.session_id.clone());
                 return Ok((result, session_id));
-            }
-            if matches!(action, FrameAction::Point) {
-                root_offset_x += result.get("offsetX").and_then(Value::as_f64).unwrap_or(0.0);
-                root_offset_y += result.get("offsetY").and_then(Value::as_f64).unwrap_or(0.0);
             }
             let index = result.get("index").and_then(Value::as_u64).unwrap_or(0) as usize;
             let src = result
@@ -3252,9 +3493,10 @@ async fn discover_ws_url(port: u16) -> Result<String> {
 mod tests {
     use super::{
         activation_verified, ax_hit_has_backend_ancestor, build_descend_js, build_frame_element_js,
-        require_frame_chain, resolve_frame_id, split_frame_chain, us_qwerty_key, uses_insert_text,
-        FrameAction, ReadMode,
+        collect_piercing_query_roots, require_frame_chain, resolve_frame_id, split_frame_chain,
+        us_qwerty_key, uses_insert_text, FrameAction, ReadMode,
     };
+    use serde_json::json;
 
     #[test]
     fn long_text_uses_atomic_trusted_insertion_by_unicode_character_count() {
@@ -3318,28 +3560,6 @@ mod tests {
     }
 
     #[test]
-    fn descend_js_locates_iframe_target_without_synthetic_clicks() {
-        let js = build_descend_js(&["iframe#f"], "button#go", &FrameAction::Point);
-        assert!(js.contains(r#"["iframe#f"]"#));
-        assert!(js.contains(r#"querySelector("button#go")"#));
-        assert!(js.contains("getBoundingClientRect"));
-        assert!(js.contains("offsetX"));
-        assert!(!js.contains("el.click();"));
-        assert!(!js.contains("dispatchEvent"));
-        assert!(js.contains("ok: false"));
-        assert!(js.contains("ok:true"));
-    }
-
-    #[test]
-    fn point_lookup_on_current_document_returns_a_box_only() {
-        let js = build_descend_js(&[], "button#go", &FrameAction::Point);
-        assert!(js.contains(r#"const chain = [];"#));
-        assert!(js.contains("halfWidth"));
-        assert!(js.contains("halfHeight"));
-        assert!(!js.contains("dispatchEvent"));
-    }
-
-    #[test]
     fn descend_js_focus_selects_only_when_clear_is_requested() {
         let append = build_descend_js(
             &["iframe#f"],
@@ -3385,6 +3605,30 @@ mod tests {
         let js = build_frame_element_js(&["iframe.inner-wrapper", "iframe.payment"], 1);
         assert!(js.contains(r#"["iframe.inner-wrapper","iframe.payment"]"#));
         assert!(!js.contains("iframe.same-origin"));
+    }
+
+    #[test]
+    fn piercing_query_roots_include_nested_shadow_roots_not_child_frames() {
+        let tree = json!({
+            "backendNodeId": 1,
+            "children": [{
+                "backendNodeId": 2,
+                "shadowRoots": [{
+                    "backendNodeId": 3,
+                    "children": [{
+                        "backendNodeId": 4,
+                        "shadowRoots": [{"backendNodeId": 5}]
+                    }]
+                }],
+                "contentDocument": {
+                    "backendNodeId": 6,
+                    "shadowRoots": [{"backendNodeId": 7}]
+                }
+            }]
+        });
+        let mut roots = Vec::new();
+        collect_piercing_query_roots(&tree, true, &mut roots);
+        assert_eq!(roots, vec![1, 3, 5]);
     }
 
     #[test]

--- a/crates/ab-browser/src/lib.rs
+++ b/crates/ab-browser/src/lib.rs
@@ -1026,6 +1026,25 @@ impl Page {
     }
 }
 
+fn ax_hit_has_backend_ancestor(nodes: &[Value], hit_backend: i64, target_backend: i64) -> bool {
+    let mut current = nodes
+        .iter()
+        .find(|node| node.get("backendDOMNodeId").and_then(Value::as_i64) == Some(hit_backend));
+    for _ in 0..nodes.len() {
+        let Some(node) = current else { return false };
+        if node.get("backendDOMNodeId").and_then(Value::as_i64) == Some(target_backend) {
+            return true;
+        }
+        let Some(parent_id) = node.get("parentId").and_then(Value::as_str) else {
+            return false;
+        };
+        current = nodes
+            .iter()
+            .find(|candidate| candidate.get("nodeId").and_then(Value::as_str) == Some(parent_id));
+    }
+    false
+}
+
 /// Actions driven by an accessibility `[ref]` (its backendDOMNodeId).
 impl Page {
     /// Resolve the on-screen center of a node from its box model.
@@ -1140,37 +1159,63 @@ impl Page {
         self.evaluate(&js).await
     }
 
-    /// Actionability hit-test: is the target node (or a descendant of it)
-    /// actually the element at viewport point (x, y)? Playwright does this before
-    /// every click so an overlay/animation covering the target doesn't steal the
-    /// click. Returns Ok(true) if the point lands on the target, Ok(false) if it
-    /// is occluded, Err only on a protocol failure (caller may then assume true).
+    /// Actionability hit-test using only browser protocol domains, avoiding
+    /// main-world Runtime execution that a page can observe. Returns true when
+    /// the point lands on the target or its accessibility ancestor chain.
     async fn point_hits_node(&self, backend: i64, x: f64, y: f64) -> Result<bool> {
-        let Some(obj) = self.resolve_object(backend).await? else {
-            return Ok(true);
-        };
-        let res = self
+        // Input events use viewport coordinates, while DOM.getNodeForLocation
+        // expects document coordinates.
+        let metrics = self
+            .client
+            .send_on(&self.session_id, "Page.getLayoutMetrics", json!({}))
+            .await?;
+        let viewport = metrics
+            .get("cssVisualViewport")
+            .or_else(|| metrics.get("visualViewport"));
+        let page_x = viewport
+            .and_then(|value| value.get("pageX"))
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0);
+        let page_y = viewport
+            .and_then(|value| value.get("pageY"))
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0);
+        let hit = self
             .client
             .send_on(
                 &self.session_id,
-                "Runtime.callFunctionOn",
+                "DOM.getNodeForLocation",
                 json!({
-                    "objectId": obj,
-                    "arguments": [{ "value": x }, { "value": y }],
-                    "returnByValue": true,
-                    "functionDeclaration": r#"function(x, y){
-                        const hit = document.elementFromPoint(x, y);
-                        if (!hit) return false;
-                        return this === hit || this.contains(hit);
-                    }"#,
+                    "x": (x + page_x).round() as i64,
+                    "y": (y + page_y).round() as i64,
+                }),
+            )
+            .await
+            .map_err(|error| {
+                BrowserError::Protocol(format!("DOM hit-test failed at ({x:.2}, {y:.2}): {error}"))
+            })?;
+        let Some(hit_backend) = hit.get("backendNodeId").and_then(Value::as_i64) else {
+            return Ok(false);
+        };
+        if hit_backend == backend {
+            return Ok(true);
+        }
+
+        let relatives = self
+            .client
+            .send_on(
+                &self.session_id,
+                "Accessibility.getPartialAXTree",
+                json!({
+                    "backendNodeId": hit_backend,
+                    "fetchRelatives": true,
                 }),
             )
             .await?;
-        Ok(res
-            .get("result")
-            .and_then(|r| r.get("value"))
-            .and_then(Value::as_bool)
-            .unwrap_or(true))
+        Ok(relatives
+            .get("nodes")
+            .and_then(Value::as_array)
+            .is_some_and(|nodes| ax_hit_has_backend_ancestor(nodes, hit_backend, backend)))
     }
 
     /// Resolve a backend node to a Runtime objectId (for JS calls on it).
@@ -3206,9 +3251,9 @@ async fn discover_ws_url(port: u16) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        activation_verified, build_descend_js, build_frame_element_js, require_frame_chain,
-        resolve_frame_id, split_frame_chain, us_qwerty_key, uses_insert_text, FrameAction,
-        ReadMode,
+        activation_verified, ax_hit_has_backend_ancestor, build_descend_js, build_frame_element_js,
+        require_frame_chain, resolve_frame_id, split_frame_chain, us_qwerty_key, uses_insert_text,
+        FrameAction, ReadMode,
     };
 
     #[test]
@@ -3233,6 +3278,22 @@ mod tests {
         assert!(activation_verified("visible", true));
         assert!(!activation_verified("visible", false));
         assert!(!activation_verified("hidden", true));
+    }
+
+    #[test]
+    fn ax_relatives_follow_ancestors_without_accepting_siblings() {
+        let nodes = serde_json::json!([
+            { "nodeId": "hit", "parentId": "target", "backendDOMNodeId": 21 },
+            { "nodeId": "target", "parentId": "root", "backendDOMNodeId": 10 },
+            { "nodeId": "sibling", "parentId": "target", "backendDOMNodeId": 99 },
+            { "nodeId": "root", "backendDOMNodeId": 1 }
+        ]);
+        let nodes = nodes.as_array().unwrap();
+
+        assert!(ax_hit_has_backend_ancestor(nodes, 21, 10));
+        assert!(ax_hit_has_backend_ancestor(nodes, 21, 1));
+        assert!(!ax_hit_has_backend_ancestor(nodes, 21, 99));
+        assert!(!ax_hit_has_backend_ancestor(nodes, 21, 404));
     }
 
     #[test]

--- a/crates/ab-browser/src/pointer.rs
+++ b/crates/ab-browser/src/pointer.rs
@@ -128,11 +128,20 @@ impl Page {
 
         match request.action {
             PointerAction::Click => {
-                self.left_click_at(x, y).await?;
+                tokio::time::sleep(Duration::from_millis(rand_u64(20, 70))).await;
+                self.require_click_target_after_move(&request.origin, (x, y))
+                    .await?;
+                self.mouse_button("mousePressed", x, y, "left", 1, 1)
+                    .await?;
+                tokio::time::sleep(Duration::from_millis(rand_u64(40, 110))).await;
+                self.mouse_button("mouseReleased", x, y, "left", 0, 1)
+                    .await?;
             }
             PointerAction::Hover => {}
             PointerAction::RightClick => {
                 tokio::time::sleep(Duration::from_millis(rand_u64(20, 70))).await;
+                self.require_click_target_after_move(&request.origin, (x, y))
+                    .await?;
                 self.mouse_button("mousePressed", x, y, "right", 2, 1)
                     .await?;
                 tokio::time::sleep(Duration::from_millis(rand_u64(40, 110))).await;
@@ -141,6 +150,8 @@ impl Page {
             }
             PointerAction::DoubleClick => {
                 for count in [1, 2] {
+                    self.require_click_target_after_move(&request.origin, (x, y))
+                        .await?;
                     self.mouse_button("mousePressed", x, y, "left", 1, count)
                         .await?;
                     tokio::time::sleep(Duration::from_millis(rand_u64(35, 95))).await;
@@ -219,7 +230,29 @@ impl Page {
                 .await?
             {
                 return Err(BrowserError::Protocol(
-                    "drag endpoint is outside the visible hit target".into(),
+                    "pointer target is outside the visible hit area".into(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Humanized travel can leave a hover-sensitive container and close its
+    /// menu. Re-check element refs immediately before pressing so that failure
+    /// is reported instead of silently clicking whatever replaced the target.
+    async fn require_click_target_after_move(
+        &self,
+        location: &PointerLocation,
+        point: (f64, f64),
+    ) -> Result<()> {
+        if let PointerLocation::Element(element) = location {
+            if !self
+                .point_hits_node(element.backend_node_id, point.0, point.1)
+                .await?
+            {
+                return Err(BrowserError::Protocol(
+                    "pointer target moved, closed, or became occluded before the click landed; retry with a fresh ref"
+                        .into(),
                 ));
             }
         }

--- a/crates/ab-browser/src/pointer.rs
+++ b/crates/ab-browser/src/pointer.rs
@@ -337,6 +337,33 @@ impl Page {
         self.left_click_at_on(session_id, frame_point.0, frame_point.1)
             .await
     }
+
+    pub(crate) async fn trusted_frame_hover_at(
+        &self,
+        session_id: &str,
+        root_point: (f64, f64),
+        frame_point: (f64, f64),
+    ) -> Result<()> {
+        for value in [root_point.0, root_point.1, frame_point.0, frame_point.1] {
+            if !value.is_finite() || value < 0.0 {
+                return Err(BrowserError::Protocol(
+                    "trusted frame hover coordinates must be finite and non-negative".into(),
+                ));
+            }
+        }
+        let _mutation = self.pointer_mutation.lock().await;
+        self.human_move_to(root_point.0, root_point.1).await?;
+        if session_id != self.session_id {
+            self.client
+                .send_on(
+                    session_id,
+                    "Input.dispatchMouseEvent",
+                    json!({ "type": "mouseMoved", "x": frame_point.0, "y": frame_point.1 }),
+                )
+                .await?;
+        }
+        Ok(())
+    }
 }
 
 fn same_document(origin: &ElementRef, destination: &ElementRef) -> bool {

--- a/crates/ab-browser/src/snapshot.rs
+++ b/crates/ab-browser/src/snapshot.rs
@@ -77,8 +77,8 @@ fn is_noise(role: &str) -> bool {
 /// (cross-origin) iframe's content is invisible to `Accessibility.getFullAXTree`
 /// entirely (separate renderer, separate CDP target) — without this line the
 /// agent would have no signal that an iframe exists at all. Use
-/// `browser_iframe_read` / `browser_iframe_click` / `browser_iframe_type` to
-/// reach inside it.
+/// `browser_iframe_read` / `browser_iframe_click` / `browser_iframe_hover` /
+/// `browser_iframe_type` to reach inside it.
 fn is_iframe(role: &str) -> bool {
     matches!(role, "Iframe" | "iframe" | "IframePresentational")
 }
@@ -172,7 +172,7 @@ fn walk(
             line.push_str(&format!(" \"{}\"", truncate(&name, 120)));
         }
         if is_iframe(role) {
-            line.push_str(" [iframe: use browser_iframe_read/_click/_fill]");
+            line.push_str(" [iframe: use browser_iframe_read/_click/_hover/_type]");
         }
         if is_interactive(role) {
             *counter += 1;

--- a/crates/ab-browser/src/stealth.rs
+++ b/crates/ab-browser/src/stealth.rs
@@ -144,12 +144,56 @@ pub const STEALTH_INIT_SCRIPT: &str = r#"
         };
       }, 'connect');
       const sendMessage = mark(function sendMessage() {}, 'sendMessage');
+      // Real Chrome exposes these frozen extension-API enums on chrome.runtime
+      // even with no extension installed. A shim that stops at connect/
+      // sendMessage/onMessage is a detectable "half a chrome.runtime".
+      const enumObj = (values) => Object.freeze({ ...values });
       window.chrome.runtime = {
         id: undefined,
         connect,
         sendMessage,
         onMessage: listener(),
         onConnect: listener(),
+        OnInstalledReason: enumObj({
+          INSTALL: 'install',
+          UPDATE: 'update',
+          CHROME_UPDATE: 'chrome_update',
+          SHARED_MODULE_UPDATE: 'shared_module_update',
+        }),
+        OnRestartRequiredReason: enumObj({
+          APP_UPDATE: 'app_update',
+          OS_UPDATE: 'os_update',
+          PERIODIC: 'periodic',
+        }),
+        PlatformArch: enumObj({
+          ARM: 'arm',
+          ARM64: 'arm64',
+          MIPS: 'mips',
+          MIPS64: 'mips64',
+          X86_32: 'x86-32',
+          X86_64: 'x86-64',
+        }),
+        PlatformNaclArch: enumObj({
+          ARM: 'arm',
+          MIPS: 'mips',
+          MIPS64: 'mips64',
+          PNACL: 'pnacl',
+          X86_32: 'x86-32',
+          X86_64: 'x86-64',
+        }),
+        PlatformOs: enumObj({
+          ANDROID: 'android',
+          CROS: 'cros',
+          LINUX: 'linux',
+          MAC: 'mac',
+          OPENBSD: 'openbsd',
+          WIN: 'win',
+        }),
+        RequestUpdateCheckStatus: enumObj({
+          THROTTLED: 'throttled',
+          NO_UPDATE: 'no_update',
+          UPDATE_AVAILABLE: 'update_available',
+        }),
       };
     }
     if (!window.chrome.csi) {

--- a/crates/ab-browser/tests/keyboard_clipboard.rs
+++ b/crates/ab-browser/tests/keyboard_clipboard.rs
@@ -1,0 +1,93 @@
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use ab_browser::{Browser, LaunchOptions};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+
+fn temporary_profile_dir() -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time is after the Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "ab-browser-clipboard-{}-{nonce}",
+        std::process::id()
+    ))
+}
+
+#[tokio::test]
+#[ignore = "requires a locally installed headful Chrome or Chromium"]
+async fn trusted_shortcuts_round_trip_through_the_clipboard() -> anyhow::Result<()> {
+    const SOURCE: &str = "clipboard round-trip";
+    let html = format!(
+        r#"<!doctype html>
+          <input id="source" value="{SOURCE}">
+          <input id="destination" value="">
+          <script>
+            document.addEventListener('copy', event => {{
+              document.body.dataset.copyTrusted = String(event.isTrusted);
+            }});
+            document.addEventListener('paste', event => {{
+              document.body.dataset.pasteTrusted = String(event.isTrusted);
+            }});
+          </script>"#
+    );
+    let url = format!("data:text/html;base64,{}", STANDARD.encode(html));
+    let profile_dir = temporary_profile_dir();
+
+    #[cfg(target_os = "macos")]
+    {
+        let status = std::process::Command::new("pbcopy")
+            .stdin(std::process::Stdio::null())
+            .status()?;
+        anyhow::ensure!(status.success(), "failed to clear the macOS pasteboard");
+    }
+
+    let browser = Browser::launch(LaunchOptions {
+        headless: false,
+        user_data_dir: Some(profile_dir.clone()),
+        ..Default::default()
+    })
+    .await?;
+    let page = browser.new_page(&url).await?;
+    let activation = page.activate().await?;
+    anyhow::ensure!(activation.activated, "Chrome page did not become active");
+
+    #[cfg(target_os = "macos")]
+    let modifier = "Meta";
+    #[cfg(not(target_os = "macos"))]
+    let modifier = "Control";
+
+    page.evaluate("document.querySelector('#source').focus()")
+        .await?;
+    page.press(&format!("{modifier}+a")).await?;
+    page.press(&format!("{modifier}+c")).await?;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    #[cfg(target_os = "macos")]
+    let os_clipboard = String::from_utf8(std::process::Command::new("pbpaste").output()?.stdout)?;
+
+    page.evaluate("document.querySelector('#destination').focus()")
+        .await?;
+    page.press(&format!("{modifier}+v")).await?;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let state = page
+        .evaluate(
+            "({ value: document.querySelector('#destination').value, copyTrusted: document.body.dataset.copyTrusted, pasteTrusted: document.body.dataset.pasteTrusted })",
+        )
+        .await?;
+
+    browser.close().await;
+    let _ = std::fs::remove_dir_all(profile_dir);
+
+    #[cfg(target_os = "macos")]
+    assert_eq!(
+        os_clipboard, SOURCE,
+        "copy did not update the OS pasteboard"
+    );
+    assert_eq!(state["value"], SOURCE, "paste did not populate the input");
+    assert_eq!(state["copyTrusted"], "true");
+    assert_eq!(state["pasteTrusted"], "true");
+    Ok(())
+}

--- a/crates/ab-browser/tests/pointer_actionability.rs
+++ b/crates/ab-browser/tests/pointer_actionability.rs
@@ -1,0 +1,200 @@
+use std::time::Duration;
+
+use ab_browser::{
+    Browser, ElementRef, LaunchOptions, Page, PointerAction, PointerLocation, PointerRequest,
+    Snapshot,
+};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+
+fn element(snapshot: &Snapshot, needle: &str) -> anyhow::Result<ElementRef> {
+    let line = snapshot
+        .text
+        .lines()
+        .find(|line| line.contains(needle) && line.contains("[ref="))
+        .ok_or_else(|| anyhow::anyhow!("snapshot has no ref containing {needle:?}"))?;
+    let start = line.find("[ref=").expect("checked above") + 5;
+    let end = start
+        + line[start..]
+            .find(']')
+            .ok_or_else(|| anyhow::anyhow!("malformed ref line: {line}"))?;
+    snapshot
+        .refs
+        .get(&line[start..end])
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("ref is absent from snapshot map: {line}"))
+}
+
+async fn act(page: &Page, action: PointerAction, target: ElementRef) -> anyhow::Result<()> {
+    page.dispatch_pointer(&PointerRequest {
+        action,
+        origin: PointerLocation::Element(target),
+        destination: None,
+        delta_x: 0.0,
+        delta_y: 0.0,
+    })
+    .await?;
+    Ok(())
+}
+
+async fn snapshot_after(page: &Page, millis: u64) -> anyhow::Result<Snapshot> {
+    tokio::time::sleep(Duration::from_millis(millis)).await;
+    Ok(page.snapshot().await?)
+}
+
+#[tokio::test]
+#[ignore = "requires a locally installed Chrome or Chromium"]
+async fn ref_pointer_actionability_regressions() -> anyhow::Result<()> {
+    let html = r#"<!doctype html>
+      <style>
+        body { margin: 0; font: 16px sans-serif; }
+        .spacer { height: 1300px; }
+        button { width: 220px; height: 48px; margin: 12px; position: relative; }
+        #nested-cover { position: absolute; inset: 0; display: grid; place-items: center; }
+        #menu-items { display: none; margin-left: 12px; }
+        #menu.open #menu-items { display: block; }
+      </style>
+      <div class="spacer"></div>
+      <button id="nested"><span id="nested-cover">Nested target</span></button>
+      <div id="nested-status">nested pending</div>
+      <div id="shadow-host"></div>
+      <div id="shadow-status">shadow pending</div>
+      <div id="menu">
+        <button id="menu-trigger">Payment method</button>
+        <div id="menu-items"><button id="menu-option">Kakao Pay</button></div>
+      </div>
+      <div id="menu-status">menu pending</div>
+      <div style="position: relative; width: 244px; height: 72px;">
+        <button id="covered">Covered target</button>
+        <button id="sibling-cover" style="position: absolute; inset: 12px; margin: 0;">Sibling cover</button>
+      </div>
+      <button id="vanish">Vanish on hover</button>
+      <button id="replace">Replace after first click</button>
+      <div id="replace-status">replace pending</div>
+      <script>
+        const nested = document.querySelector('#nested');
+        const nestedStatus = document.querySelector('#nested-status');
+        const shadowStatus = document.querySelector('#shadow-status');
+        const menu = document.querySelector('#menu');
+        const menuOption = document.querySelector('#menu-option');
+        const menuStatus = document.querySelector('#menu-status');
+        const vanish = document.querySelector('#vanish');
+        const replace = document.querySelector('#replace');
+        const replaceStatus = document.querySelector('#replace-status');
+        nested.addEventListener('click', () => nestedStatus.textContent = 'nested clicked');
+
+        const root = document.querySelector('#shadow-host').attachShadow({mode: 'closed'});
+        const shadowButton = document.createElement('button');
+        shadowButton.textContent = 'Shadow action';
+        shadowButton.addEventListener('click', () => shadowStatus.textContent = 'shadow clicked');
+        root.append(shadowButton);
+
+        let closeTimer = 0;
+        menu.addEventListener('mouseenter', () => {
+          clearTimeout(closeTimer);
+          menu.classList.add('open');
+        });
+        menu.addEventListener('mouseleave', () => {
+          closeTimer = setTimeout(() => menu.classList.remove('open'), 200);
+        });
+        menuOption.addEventListener('click', () => menuStatus.textContent = 'menu clicked');
+
+        vanish.addEventListener('mouseenter', () => vanish.remove());
+        replace.addEventListener('click', () => {
+          replaceStatus.textContent = 'first click dispatched';
+          const replacement = document.createElement('button');
+          replacement.textContent = 'Replacement';
+          replace.replaceWith(replacement);
+        }, {once: true});
+      </script>"#;
+    let url = format!("data:text/html;base64,{}", STANDARD.encode(html));
+    let browser = Browser::launch(LaunchOptions {
+        headless: true,
+        ..Default::default()
+    })
+    .await?;
+    let page = browser.new_page(&url).await?;
+
+    let snapshot = snapshot_after(&page, 150).await?;
+    act(
+        &page,
+        PointerAction::Click,
+        element(&snapshot, "Nested target")?,
+    )
+    .await?;
+    assert!(snapshot_after(&page, 50)
+        .await?
+        .text
+        .contains("nested clicked"));
+
+    let snapshot = page.snapshot().await?;
+    act(
+        &page,
+        PointerAction::Click,
+        element(&snapshot, "Shadow action")?,
+    )
+    .await?;
+    assert!(snapshot_after(&page, 50)
+        .await?
+        .text
+        .contains("shadow clicked"));
+
+    let snapshot = page.snapshot().await?;
+    act(
+        &page,
+        PointerAction::Hover,
+        element(&snapshot, "Payment method")?,
+    )
+    .await?;
+    let snapshot = snapshot_after(&page, 50).await?;
+    act(
+        &page,
+        PointerAction::Click,
+        element(&snapshot, "Kakao Pay")?,
+    )
+    .await?;
+    assert!(snapshot_after(&page, 50)
+        .await?
+        .text
+        .contains("menu clicked"));
+
+    let snapshot = page.snapshot().await?;
+    let error = act(
+        &page,
+        PointerAction::Click,
+        element(&snapshot, "Covered target")?,
+    )
+    .await
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("outside the visible hit area"), "{error}");
+
+    let snapshot = page.snapshot().await?;
+    let error = act(
+        &page,
+        PointerAction::Click,
+        element(&snapshot, "Vanish on hover")?,
+    )
+    .await
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("before the click landed"), "{error}");
+
+    let snapshot = page.snapshot().await?;
+    let error = act(
+        &page,
+        PointerAction::DoubleClick,
+        element(&snapshot, "Replace after first click")?,
+    )
+    .await
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("before the click landed"), "{error}");
+    assert!(page
+        .snapshot()
+        .await?
+        .text
+        .contains("first click dispatched"));
+
+    browser.close().await;
+    Ok(())
+}

--- a/crates/ab-browser/tests/pointer_actionability.rs
+++ b/crates/ab-browser/tests/pointer_actionability.rs
@@ -70,6 +70,7 @@ async fn ref_pointer_actionability_regressions() -> anyhow::Result<()> {
       <button id="vanish">Vanish on hover</button>
       <button id="replace">Replace after first click</button>
       <div id="replace-status">replace pending</div>
+      <iframe id="action-frame" style="width: 360px; height: 180px;"></iframe>
       <script>
         const nested = document.querySelector('#nested');
         const nestedStatus = document.querySelector('#nested-status');
@@ -105,6 +106,35 @@ async fn ref_pointer_actionability_regressions() -> anyhow::Result<()> {
           replacement.textContent = 'Replacement';
           replace.replaceWith(replacement);
         }, {once: true});
+
+        const frame = document.querySelector('#action-frame');
+        frame.srcdoc = `<!doctype html>
+          <style>
+            body { margin: 0; font: 16px sans-serif; }
+            button { width: 220px; height: 48px; margin: 8px; }
+          </style>
+          <div id="shadow-host"></div>
+          <div id="status">iframe pending</div>
+          <script>
+            const status = document.querySelector('#status');
+            const root = document.querySelector('#shadow-host').attachShadow({mode: 'closed'});
+            const direct = document.createElement('button');
+            direct.id = 'shadow-direct';
+            direct.textContent = 'Iframe shadow action';
+            direct.addEventListener('click', () => status.textContent = 'iframe shadow clicked');
+            const menu = document.createElement('div');
+            const trigger = document.createElement('button');
+            trigger.id = 'menu-trigger';
+            trigger.textContent = 'Iframe payment method';
+            const option = document.createElement('button');
+            option.id = 'menu-option';
+            option.textContent = 'Iframe Kakao Pay';
+            option.style.display = 'none';
+            trigger.addEventListener('mouseenter', () => option.style.display = 'block');
+            option.addEventListener('click', () => status.textContent = 'iframe menu clicked');
+            menu.append(trigger, option);
+            root.append(direct, menu);
+          <\/script>`;
       </script>"#;
     let url = format!("data:text/html;base64,{}", STANDARD.encode(html));
     let browser = Browser::launch(LaunchOptions {
@@ -194,6 +224,21 @@ async fn ref_pointer_actionability_regressions() -> anyhow::Result<()> {
         .await?
         .text
         .contains("first click dispatched"));
+
+    page.iframe_click("#action-frame", "#shadow-direct").await?;
+    assert_eq!(
+        page.iframe_read("#action-frame", "#status", ab_browser::ReadMode::Text)
+            .await?,
+        "iframe shadow clicked"
+    );
+
+    page.iframe_hover("#action-frame", "#menu-trigger").await?;
+    page.iframe_click("#action-frame", "#menu-option").await?;
+    assert_eq!(
+        page.iframe_read("#action-frame", "#status", ab_browser::ReadMode::Text)
+            .await?,
+        "iframe menu clicked"
+    );
 
     browser.close().await;
     Ok(())

--- a/crates/ab-mcp/src/main.rs
+++ b/crates/ab-mcp/src/main.rs
@@ -645,7 +645,8 @@ struct IframeClickArgs {
     /// both supported and require no special handling from the caller. See
     /// the `frame_selector` known-limitations note above this struct.
     frame_selector: String,
-    /// CSS selector for the element inside the innermost iframe.
+    /// CSS selector for the element inside the innermost iframe. Click and
+    /// hover resolution pierce open and closed shadow roots.
     selector: String,
 }
 
@@ -2286,6 +2287,22 @@ impl BrowserServer {
         Ok(ok(format!("iframe-clicked on {}\n\n{}", a.page, diff)))
     }
 
+    /// Hover inside an iframe with trusted browser-generated pointer input.
+    #[tool(
+        description = "Hover an element inside a same-origin or cross-origin iframe using trusted CDP pointer input; pierces closed shadow roots; chain nested iframes in frame_selector with ' >> '"
+    )]
+    async fn browser_iframe_hover(
+        &self,
+        Parameters(a): Parameters<IframeClickArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let page = self.page_of(&a.page).await?;
+        page.iframe_hover(&a.frame_selector, &a.selector)
+            .await
+            .map_err(fail)?;
+        let diff = self.settle_diff(&a.page, &page).await?;
+        Ok(ok(format!("iframe-hovered on {}\n\n{}", a.page, diff)))
+    }
+
     /// Type into an input inside an iframe using trusted CDP keyboard input.
     #[tool(
         description = "Type text into an element inside a same-origin or cross-origin iframe using trusted CDP keyboard input; chain nested iframes in frame_selector with ' >> '; waits by default and supports browser_cancel_typing when wait=false"
@@ -3148,6 +3165,7 @@ mod tests {
         assert!(names.contains(&"browser_pointer"));
         assert!(names.contains(&"browser_wheel"));
         assert!(names.contains(&"browser_cancel_typing"));
+        assert!(names.contains(&"browser_iframe_hover"));
         assert!(names.contains(&"browser_iframe_type"));
     }
 

--- a/crates/ab-mcp/src/main.rs
+++ b/crates/ab-mcp/src/main.rs
@@ -407,7 +407,7 @@ fn default_true() -> bool {
 #[derive(Debug, Deserialize, JsonSchema)]
 struct PressArgs {
     page: String,
-    /// Key name: Enter, Tab, Escape, Backspace, ArrowUp, ArrowDown, or a character.
+    /// Key name or modifier combo, such as Enter, Meta+c, or Control+Shift+v.
     key: String,
     /// Optionally focus this ref/selector before pressing.
     #[serde(default, rename = "ref")]
@@ -1462,7 +1462,9 @@ impl BrowserServer {
     }
 
     /// Press a named key on a page, then report what changed.
-    #[tool(description = "Press a key (Enter, Tab, Escape, ...); returns settle-diff")]
+    #[tool(
+        description = "Press a key or modifier combo (Enter, Meta+c, Control+v, ...); returns settle-diff"
+    )]
     async fn browser_press_key(
         &self,
         Parameters(a): Parameters<PressArgs>,


### PR DESCRIPTION
## Summary
- Actionability hit-testing is now Runtime-free and pierces closed shadow roots (including inside iframes) via `Page.getLayoutMetrics` + `DOM.getNodeForLocation` + `Accessibility.getPartialAXTree`, replacing a main-world `document.elementFromPoint` call that always failed for closed-shadow targets.
- The target is now re-verified immediately before every `mousePressed` (not just once before the human-like travel), so a hover-menu closing mid-move fails loudly with a clear error instead of silently pressing the wrong element.
- `browser_iframe_click` gained the same closed-shadow-piercing resolution; new `browser_iframe_hover` tool lets a hover-to-reveal menu inside an iframe open without any manual coordinate math.
- Modifier-combo key dispatch (`Meta+c`, `Ctrl+v`, …) now attaches the matching `Input.dispatchKeyEvent` `commands` (Copy/Paste/Cut/SelectAll) — CDP-synthesized key events bypass Chrome's native UI accelerator table, so Copy/Paste never reached the real OS clipboard without this.
- `chrome.runtime` shim gained the six frozen extension-API enums (`OnInstalledReason`, `OnRestartRequiredReason`, `PlatformArch`, `PlatformNaclArch`, `PlatformOs`, `RequestUpdateCheckStatus`) real Chrome exposes even with no extension installed — their total absence was previously the single biggest passive-fingerprint tell against a live bot-detection lab.

All four fixes were verified live against an independent bot-detection lab (lab.otium.team): closed-shadow keypad/hover-menu clicks now succeed by ref with zero manual pixel math, clipboard copy/paste round-trips through the real macOS pasteboard (`pbpaste` confirmed), and the passive fingerprint score dropped from 39/100 ("Uncanny Valley") to 0/100 ("Certified Human") with the chrome.runtime fix alone.

## Test plan
- [x] `cargo build` / `cargo test --workspace` / `cargo clippy --all-targets -- -D warnings` / `cargo fmt --all -- --check` all pass
- [x] Real-Chrome `#[ignore]`d integration tests pass locally (`pointer_actionability.rs`, `keyboard_clipboard.rs`)
- [x] Live-verified against lab.otium.team: closed-shadow keypad (Step 2) and both hover-menu variants (in-page + iframe, Steps 7/8) complete via ref/`browser_iframe_hover` with zero manual coordinate math
- [x] Live-verified clipboard round-trip via `pbpaste` on macOS
- [x] Passive fingerprint score improved 39/100 → 0/100 on the same live lab after the chrome.runtime fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)