### PR TITLE
release: v0.3.1 macOS native-modal safety, non-Latin type-ahead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ab-browser"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ab-cdp",
  "anyhow",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "ab-cdp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "futures-util",
  "serde",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "ab-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ab-browser",
  "ab-cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/ab-cdp", "crates/ab-browser", "crates/ab-mcp"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,7 +22,7 @@ browser-rs --help
 
 ```bash
 # Pin a specific version
-curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | AB_VERSION=v0.3.0 sh
+curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | AB_VERSION=v0.3.1 sh
 
 # Choose the install directory
 AB_BIN_DIR=~/bin curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | sh

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ browser-rs --help
 To pin this release instead of following `latest`:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | AB_VERSION=v0.3.0 sh
+curl -fsSL https://raw.githubusercontent.com/maestrojeong/browser-rs-mcp/main/install.sh | AB_VERSION=v0.3.1 sh
 ```
 
 **2. Run** — use stdio for a client that launches the server:
@@ -90,7 +90,42 @@ cargo install --git https://github.com/maestrojeong/browser-rs-mcp ab-mcp
 Set `AB_CHROME` if Chrome is not in a standard location.
 
 <details>
-<summary><strong>What's new (v0.1.14 - v0.3.0)</strong></summary>
+<summary><strong>What's new (v0.1.14 - v0.3.1)</strong></summary>
+
+**v0.3.1 — native modal safety and non-Latin type-ahead.** On macOS, a left
+`mousePressed` landing on a collapsed, enabled, single-option `<select>`
+(native `NSPopUpButton`) or an enabled `<input type="file">` (native
+`NSOpenPanel`) hands off to a Cocoa modal run loop that blocks the browser
+process's main thread until it's dismissed by native input CDP cannot
+send — every subsequent CDP call then hangs until its own timeout fires,
+which previously read to callers as a multi-minute stall or a dead
+connection. Every left-button press this crate issues (by ref, by raw
+coordinates, as a drag origin, or against an out-of-process iframe
+session) now hit-tests its target via `DOM.getNodeForLocation`
+immediately before the press and rejects with a clear error pointing at
+`browser_select_option` / `browser_file_upload` if it resolves to either
+of those elements; `multiple` selects, `size>1` listboxes, and `disabled`
+elements don't open a native modal and are left alone. The same
+activation keys a real select popup responds to (Space, Enter, arrows,
+Home/End/PageUp/PageDown) are checked the same way against
+`document.activeElement` before `browser_press_key` sends them, and a
+space character typed into a focused select via
+`browser_type`/`browser_fill_form` gets the same check mid-string. All of
+these checks fail closed — a hit-test/inspection error refuses the action
+rather than risking the hang. Known gap: the keyboard-side checks only
+look at the top-level page's focus, so `browser_press_key`/`browser_type`
+into an out-of-process iframe's own CDP session aren't covered yet — only
+the mouse-side check (`browser_iframe_click`) is. Separately,
+`browser_select_option`'s trusted
+type-ahead search failed silently on non-Latin option labels (Korean,
+Japanese, Chinese, ...) because the US-QWERTY key table maps them to
+`windowsVirtualKeyCode: 0`, which Blink treats as a non-character key and
+never turns into the `keypress` type-ahead search reads; those characters
+now carry `VK_PROCESSKEY` (229), the same code real browsers send for
+IME-composed input, so Blink synthesizes the keypress and the search
+matches. A left-open JS dialog now gets one retry (with a logged error if
+that also fails) instead of a silently swallowed
+`Page.handleJavaScriptDialog` failure.
 
 **v0.3.0 — native page APIs and grounded input models.** browser-rs no longer
 injects a pre-document JavaScript stealth script. A real Chrome now exposes its

--- a/crates/ab-browser/src/lib.rs
+++ b/crates/ab-browser/src/lib.rs
@@ -1459,6 +1459,15 @@ impl Page {
                 }
                 return Err(BrowserError::TypingCancelled);
             }
+            // A space keystroke is also the native "open the dropdown"
+            // activation key for a focused <select> on macOS — see
+            // `reject_if_key_would_open_focused_select_popup`. Typed text
+            // containing a space (e.g. filling "Productivity Apps" into a
+            // select-labeled form field) can hit this mid-string.
+            if ch == ' ' {
+                self.reject_if_key_would_open_focused_select_popup(" ")
+                    .await?;
+            }
             let s = ch.to_string();
             let (code, vk) = us_qwerty_key(ch);
             let need_shift = needs_shift(ch);
@@ -2462,6 +2471,7 @@ impl Page {
         if let Some(combo) = parse_key_combo(key)? {
             return self.dispatch_key_combo(session_id, combo).await;
         }
+        self.reject_if_key_would_open_focused_select_popup(key).await?;
 
         let (event_key, code, vk) = key_definition(key);
         self.client
@@ -2498,6 +2508,79 @@ impl Page {
             82.0, 0.32, 25, 240,
         )))
         .await;
+        Ok(())
+    }
+
+    /// On macOS, Space/Enter and the arrow/paging/Home/End keys are native
+    /// "open the dropdown" activation keys for a focused, popup-capable
+    /// `<select>` — the same `NSPopUpButton` hang risk as a mouse click (see
+    /// `pointer::reject_if_native_select_popup`), just reached through the
+    /// keyboard. Keyboard events don't carry a target coordinate to
+    /// hit-test, so this reads `document.activeElement` in an isolated
+    /// world instead (no `main_world`/`Runtime.enable` needed).
+    ///
+    /// Only checks the top-level page's focus (`self.session_id`); a
+    /// same-session `browser_press_key`/`browser_type` call into an
+    /// out-of-process iframe still bypasses this — see the v0.3.1 changelog
+    /// note.
+    async fn reject_if_key_would_open_focused_select_popup(&self, key: &str) -> Result<()> {
+        if !cfg!(target_os = "macos") {
+            return Ok(());
+        }
+        const ACTIVATION_KEYS: &[&str] = &[
+            " ",
+            "Space",
+            "Enter",
+            "ArrowUp",
+            "ArrowDown",
+            "ArrowLeft",
+            "ArrowRight",
+            "PageUp",
+            "PageDown",
+            "Home",
+            "End",
+        ];
+        if !ACTIVATION_KEYS.contains(&key) {
+            return Ok(());
+        }
+        let focused = self
+            .evaluate(
+                "(() => { const el = document.activeElement; if (!el) return null; \
+                 return { tag: el.tagName, multiple: !!el.multiple, \
+                 size: el.size || 1, disabled: !!el.disabled }; })()",
+            )
+            .await
+            .map_err(|error| {
+                BrowserError::Protocol(format!(
+                    "cannot verify the focused element is safe on macOS before \
+                     sending {key:?}; refusing rather than risking a \
+                     native-popup hang: {error}"
+                ))
+            })?;
+        let is_select = focused
+            .get("tag")
+            .and_then(Value::as_str)
+            .is_some_and(|tag| tag.eq_ignore_ascii_case("select"));
+        if !is_select {
+            return Ok(());
+        }
+        let is_multiple = focused
+            .get("multiple")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let size = focused.get("size").and_then(Value::as_i64).unwrap_or(1);
+        let is_disabled = focused
+            .get("disabled")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if pointer::select_is_popup_capable(is_multiple, size, is_disabled) {
+            return Err(BrowserError::Protocol(format!(
+                "sending {key:?} to a focused native single-option <select> \
+                 on macOS can open an OS-level popup menu that blocks CDP \
+                 for minutes; use browser_select_option (trusted \
+                 type-ahead) instead"
+            )));
+        }
         Ok(())
     }
 
@@ -2584,7 +2667,7 @@ impl Page {
     async fn type_select_search_on(&self, session_id: &str, label: &str) -> Result<()> {
         for ch in label.to_lowercase().chars() {
             let key = ch.to_string();
-            let (code, vk) = us_qwerty_key(ch);
+            let (code, vk) = type_ahead_key(ch);
             let modifiers = if needs_shift(ch) { 8 } else { 0 };
             self.client
                 .send_on(
@@ -3197,9 +3280,28 @@ impl Page {
                     if let Some(t) = text {
                         params["promptText"] = json!(t);
                     }
-                    let _ = client
-                        .send_on(&sid, "Page.handleJavaScriptDialog", params)
-                        .await;
+                    // A left-open dialog blocks every later CDP call on this
+                    // session until it's dismissed (same failure class as
+                    // the macOS native-popup hangs elsewhere in this crate),
+                    // so retry once instead of silently leaving it open.
+                    if let Err(error) = client
+                        .send_on(&sid, "Page.handleJavaScriptDialog", params.clone())
+                        .await
+                    {
+                        tracing::warn!(
+                            %error,
+                            "Page.handleJavaScriptDialog failed; retrying once"
+                        );
+                        if let Err(error) =
+                            client.send_on(&sid, "Page.handleJavaScriptDialog", params).await
+                        {
+                            tracing::error!(
+                                %error,
+                                "Page.handleJavaScriptDialog failed twice; a JS dialog \
+                                 may be left open, blocking further CDP calls on this page"
+                            );
+                        }
+                    }
                 }
             }
         });
@@ -3671,6 +3773,17 @@ fn us_qwerty_key(ch: char) -> (&'static str, u32) {
     }
 }
 
+/// `<select>` type-ahead needs a nonzero `windowsVirtualKeyCode`, or Blink
+/// treats the keyDown as non-character and never emits the keypress the
+/// search reads. `us_qwerty_key` only covers ASCII, so non-Latin characters
+/// (Hangul, CJK, ...) get the same VK_PROCESSKEY (229) real browsers send
+/// for IME-composed input.
+fn type_ahead_key(ch: char) -> (&'static str, u32) {
+    const VK_PROCESSKEY: u32 = 229;
+    let (code, vk) = us_qwerty_key(ch);
+    (code, if vk == 0 { VK_PROCESSKEY } else { vk })
+}
+
 /// Binary random-utility choice: direct typing cost grows with length while
 /// paste cost is approximately constant, yielding a logistic choice curve.
 fn paste_probability(text_len: usize, midpoint_chars: f64, slope: f64) -> f64 {
@@ -3795,7 +3908,7 @@ mod tests {
         collect_piercing_query_roots, drag_step_probability, fitts_duration_ms, minimum_jerk,
         movement_step_count, parse_key_combo, paste_probability, require_frame_chain,
         resolve_frame_id, shortcut_command, should_paste_text_for_draw, split_frame_chain,
-        us_qwerty_key, FrameAction, KeyCombo, KeyModifier, ReadMode,
+        type_ahead_key, us_qwerty_key, FrameAction, KeyCombo, KeyModifier, ReadMode,
     };
     use serde_json::json;
 
@@ -3853,6 +3966,16 @@ mod tests {
         assert_eq!(us_qwerty_key('!'), ("Digit1", 49));
         assert_eq!(us_qwerty_key('?'), ("Slash", 191));
         assert_eq!(us_qwerty_key('한'), ("", 0));
+    }
+
+    #[test]
+    fn type_ahead_key_gives_non_ascii_a_nonzero_vk_but_leaves_ascii_untouched() {
+        // ASCII: passes through us_qwerty_key's real VK unchanged.
+        assert_eq!(type_ahead_key('a'), ("KeyA", 65));
+        // Non-Latin (Hangul, e.g. "생산성"'s first syllable): vk 0 -> VK_PROCESSKEY,
+        // code stays "" (real IME-composed keys don't carry a physical code either).
+        assert_eq!(type_ahead_key('생'), ("", 229));
+        assert_eq!(type_ahead_key('한'), ("", 229));
     }
 
     #[test]

--- a/crates/ab-browser/src/lib.rs
+++ b/crates/ab-browser/src/lib.rs
@@ -2471,7 +2471,8 @@ impl Page {
         if let Some(combo) = parse_key_combo(key)? {
             return self.dispatch_key_combo(session_id, combo).await;
         }
-        self.reject_if_key_would_open_focused_select_popup(key).await?;
+        self.reject_if_key_would_open_focused_select_popup(key)
+            .await?;
 
         let (event_key, code, vk) = key_definition(key);
         self.client
@@ -3292,8 +3293,9 @@ impl Page {
                             %error,
                             "Page.handleJavaScriptDialog failed; retrying once"
                         );
-                        if let Err(error) =
-                            client.send_on(&sid, "Page.handleJavaScriptDialog", params).await
+                        if let Err(error) = client
+                            .send_on(&sid, "Page.handleJavaScriptDialog", params)
+                            .await
                         {
                             tracing::error!(
                                 %error,

--- a/crates/ab-browser/src/pointer.rs
+++ b/crates/ab-browser/src/pointer.rs
@@ -6,7 +6,7 @@
 use std::time::Duration;
 
 use serde::Serialize;
-use serde_json::json;
+use serde_json::{json, Value};
 
 use crate::{sample_lognormal_ms, BrowserError, ElementRef, Page, Result};
 
@@ -288,6 +288,14 @@ impl Page {
         button: &str,
         state: (u8, u8),
     ) -> Result<()> {
+        // Single choke point for every left-button press this crate issues —
+        // by ref, by raw coordinates, as a drag origin, or against an
+        // out-of-process iframe session. Checking here (instead of in each
+        // caller) is what makes the macOS native-<select> guard below apply
+        // uniformly instead of only to the ref-based click path.
+        if kind == "mousePressed" && button == "left" {
+            self.reject_if_native_modal_target(session_id, x, y).await?;
+        }
         let (buttons, click_count) = state;
         self.client
             .send_on(
@@ -299,6 +307,102 @@ impl Page {
                 }),
             )
             .await?;
+        Ok(())
+    }
+
+    /// On macOS, a left `mousePressed` landing on a collapsed single-option
+    /// `<select>` (native `NSPopUpButton`) or an enabled `<input
+    /// type="file">` (native `NSOpenPanel`) hands off to a Cocoa modal
+    /// run loop that blocks the browser process's main thread until it's
+    /// dismissed by *native* input CDP cannot send — every later CDP call
+    /// (mouseReleased, hit-test/settle checks) then hangs until its own
+    /// timeout fires, which reads to callers as a multi-minute stall or a
+    /// dead connection. `multiple` selects, `size>1` listboxes, and
+    /// `disabled` elements don't open either native modal and are left
+    /// alone, so this doesn't dead-end into the trusted alternatives
+    /// (`browser_select_option`, `browser_file_upload`), which only cover
+    /// that same non-modal-triggering case anyway.
+    ///
+    /// Fails *closed*: if the hit-test or node inspection itself errors, the
+    /// coordinates are treated as unsafe rather than silently proceeding
+    /// into a possible hang.
+    async fn reject_if_native_modal_target(&self, session_id: &str, x: f64, y: f64) -> Result<()> {
+        if !cfg!(target_os = "macos") {
+            return Ok(());
+        }
+        fn unsafe_to_verify(error: impl std::fmt::Display) -> BrowserError {
+            BrowserError::Protocol(format!(
+                "cannot verify this click target is safe on macOS before \
+                 mousePressed; refusing rather than risking a native-popup \
+                 hang: {error}"
+            ))
+        }
+        let metrics = self
+            .client
+            .send_on(session_id, "Page.getLayoutMetrics", json!({}))
+            .await
+            .map_err(unsafe_to_verify)?;
+        let viewport = metrics
+            .get("cssVisualViewport")
+            .or_else(|| metrics.get("visualViewport"));
+        let page_x = viewport
+            .and_then(|v| v.get("pageX"))
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0);
+        let page_y = viewport
+            .and_then(|v| v.get("pageY"))
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0);
+        let hit = self
+            .client
+            .send_on(
+                session_id,
+                "DOM.getNodeForLocation",
+                json!({
+                    "x": (x + page_x).round() as i64,
+                    "y": (y + page_y).round() as i64,
+                }),
+            )
+            .await
+            .map_err(unsafe_to_verify)?;
+        let Some(backend) = hit.get("backendNodeId").and_then(Value::as_i64) else {
+            // Nothing hit-testable at this point (e.g. blank canvas) — safe.
+            return Ok(());
+        };
+        let described = self
+            .client
+            .send_on(
+                session_id,
+                "DOM.describeNode",
+                json!({ "backendNodeId": backend }),
+            )
+            .await
+            .map_err(unsafe_to_verify)?;
+        let Some(node) = described.get("node") else {
+            return Err(BrowserError::Protocol(
+                "cannot verify this click target is safe on macOS before \
+                 mousePressed; refusing rather than risking a native-popup hang"
+                    .into(),
+            ));
+        };
+        if is_popup_capable_select(node) {
+            return Err(BrowserError::Protocol(
+                "clicking a native single-option <select> on macOS opens an \
+                 OS-level popup menu that blocks CDP for minutes; use \
+                 browser_select_option (trusted type-ahead) instead of \
+                 browser_click/browser_pointer for this element"
+                    .into(),
+            ));
+        }
+        if is_native_file_picker_input(node) {
+            return Err(BrowserError::Protocol(
+                "clicking a native <input type=\"file\"> on macOS opens an \
+                 OS-level file picker that blocks CDP for minutes; use \
+                 browser_file_upload (trusted DOM.setFileInputFiles) \
+                 instead of browser_click/browser_pointer for this element"
+                    .into(),
+            ));
+        }
         Ok(())
     }
 
@@ -381,6 +485,65 @@ impl Page {
 
 fn same_document(origin: &ElementRef, destination: &ElementRef) -> bool {
     origin.document.is_some() && origin.document == destination.document
+}
+
+/// A `DOM.describeNode` `node`'s tag name, uppercased.
+fn node_tag(node: &Value) -> String {
+    node.get("nodeName")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_ascii_uppercase()
+}
+
+/// An attribute value from a `DOM.describeNode` `node`'s flat
+/// `[name, value, name, value, ...]` attributes array.
+fn node_attr<'a>(node: &'a Value, name: &str) -> Option<&'a str> {
+    node.get("attributes")?
+        .as_array()?
+        .chunks(2)
+        .find(|pair| pair.first().and_then(Value::as_str) == Some(name))
+        .and_then(|pair| pair.get(1))
+        .and_then(Value::as_str)
+}
+
+/// Whether a `DOM.describeNode` `node` payload is a `<select>` that Chrome
+/// renders as a real popup menu on macOS (see `reject_if_native_modal_target`
+/// for why that matters). `multiple`, `size > 1`, and `disabled` selects
+/// don't open a native popup, so they're excluded here.
+fn is_popup_capable_select(node: &Value) -> bool {
+    if node_tag(node) != "SELECT" {
+        return false;
+    }
+    let is_multiple = node_attr(node, "multiple").is_some();
+    let size: i64 = node_attr(node, "size")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1);
+    let is_disabled = node_attr(node, "disabled").is_some();
+    select_is_popup_capable(is_multiple, size, is_disabled)
+}
+
+/// Whether a `DOM.describeNode` `node` payload is an enabled
+/// `<input type="file">`, which opens a native OS file picker
+/// (`NSOpenPanel` on macOS) on click — the same modal-run-loop hang risk as
+/// [`is_popup_capable_select`]. A `disabled` file input opens nothing.
+fn is_native_file_picker_input(node: &Value) -> bool {
+    if node_tag(node) != "INPUT" {
+        return false;
+    }
+    let type_attr = node_attr(node, "type").unwrap_or("text");
+    if !type_attr.eq_ignore_ascii_case("file") {
+        return false;
+    }
+    node_attr(node, "disabled").is_none()
+}
+
+/// Shared predicate behind [`is_popup_capable_select`] (mouse path, reads
+/// `DOM.describeNode` attributes) and the keyboard-focus check in
+/// `Page::reject_if_key_would_open_focused_select_popup` (reads
+/// `document.activeElement` fields), so the two paths can't drift apart on
+/// what counts as "the collapsed, enabled, single-option case".
+pub(crate) fn select_is_popup_capable(is_multiple: bool, size: i64, is_disabled: bool) -> bool {
+    !is_multiple && size <= 1 && !is_disabled
 }
 
 fn validate_request(request: &PointerRequest) -> Result<()> {
@@ -483,5 +646,89 @@ mod tests {
         let mut unproven = element("loader-a");
         unproven.document = None;
         assert!(!same_document(&unproven, &unproven));
+    }
+
+    fn describe_node(tag: &str, attrs: &[(&str, &str)]) -> Value {
+        let flat: Vec<Value> = attrs
+            .iter()
+            .flat_map(|(k, v)| [json!(k), json!(v)])
+            .collect();
+        json!({ "nodeName": tag, "attributes": flat })
+    }
+
+    #[test]
+    fn collapsed_single_select_is_popup_capable() {
+        assert!(is_popup_capable_select(&describe_node("select", &[])));
+        assert!(is_popup_capable_select(&describe_node(
+            "SELECT",
+            &[("id", "primaryCategory")]
+        )));
+    }
+
+    #[test]
+    fn non_select_tag_is_never_popup_capable() {
+        assert!(!is_popup_capable_select(&describe_node("div", &[])));
+        assert!(!is_popup_capable_select(&describe_node("input", &[])));
+    }
+
+    #[test]
+    fn multiple_select_is_not_popup_capable() {
+        assert!(!is_popup_capable_select(&describe_node(
+            "select",
+            &[("multiple", "")]
+        )));
+    }
+
+    #[test]
+    fn listbox_sized_select_is_not_popup_capable() {
+        assert!(!is_popup_capable_select(&describe_node(
+            "select",
+            &[("size", "4")]
+        )));
+        // size="1" is explicitly still the collapsed popup form.
+        assert!(is_popup_capable_select(&describe_node(
+            "select",
+            &[("size", "1")]
+        )));
+    }
+
+    #[test]
+    fn disabled_select_is_not_popup_capable() {
+        assert!(!is_popup_capable_select(&describe_node(
+            "select",
+            &[("disabled", "")]
+        )));
+    }
+
+    #[test]
+    fn enabled_file_input_is_a_native_picker() {
+        assert!(is_native_file_picker_input(&describe_node(
+            "input",
+            &[("type", "file")]
+        )));
+        // Case-insensitive, matches HTML attribute matching.
+        assert!(is_native_file_picker_input(&describe_node(
+            "INPUT",
+            &[("type", "FILE")]
+        )));
+    }
+
+    #[test]
+    fn disabled_file_input_is_not_a_native_picker() {
+        assert!(!is_native_file_picker_input(&describe_node(
+            "input",
+            &[("type", "file"), ("disabled", "")]
+        )));
+    }
+
+    #[test]
+    fn non_file_input_is_not_a_native_picker() {
+        assert!(!is_native_file_picker_input(&describe_node(
+            "input",
+            &[("type", "text")]
+        )));
+        // No `type` attribute defaults to "text" per the HTML spec.
+        assert!(!is_native_file_picker_input(&describe_node("input", &[])));
+        assert!(!is_native_file_picker_input(&describe_node("select", &[])));
     }
 }

--- a/crates/ab-browser/src/stealth.rs
+++ b/crates/ab-browser/src/stealth.rs
@@ -7,14 +7,12 @@
 //! done **without** calling `Runtime.enable` / `Console.enable`, which are the
 //! high-signal CDP tells Patchright removes. Not enabling them = nothing to hide.
 
-/// Minimal launch flags. The only fingerprint-relevant one is
-/// `--disable-blink-features=AutomationControlled`, which keeps
-/// `navigator.webdriver` naturally false without any page-visible patch. The
-/// rest just suppress first-run/keychain noise. We intentionally keep this list
-/// short: every extra flag is a way the launch can differ from a human's Chrome.
+/// Minimal launch flags. Kept short deliberately: every extra flag is a way
+/// the launch can differ from a human's Chrome.
 pub fn launch_flags() -> Vec<String> {
     [
-        // The one fingerprint-relevant flag: keeps navigator.webdriver false.
+        // The only fingerprint-relevant flag: keeps navigator.webdriver
+        // naturally false without a page-visible patch.
         "--disable-blink-features=AutomationControlled",
         // Hide the "Chrome is being controlled by automated software" infobar
         // (ported from patchright's default args).

--- a/crates/ab-mcp/src/main.rs
+++ b/crates/ab-mcp/src/main.rs
@@ -217,9 +217,7 @@ fn configured_max_output_limit() -> usize {
     })
 }
 
-/// Clamp a caller-supplied output limit to the configured ceiling so no
-/// request can force an unbounded allocation/response, no matter what value
-/// is sent.
+/// Clamp a caller-supplied output limit to `configured_max_output_limit()`.
 fn clamp_output_limit(requested: usize) -> usize {
     requested.min(configured_max_output_limit())
 }


### PR DESCRIPTION
## Summary
- macOS 네이티브 `<select>` (`NSPopUpButton`) / `<input type="file">` (`NSOpenPanel`)를 클릭하면 브라우저 프로세스 메인 스레드가 진짜 OS 모달에 점유당해 이후 모든 CDP 호출이 각자 타임아웃까지 hang하던 문제를 고쳤습니다. 이 크레이트가 보내는 모든 left mousePressed(ref/좌표/drag origin/iframe)가 press 직전 `DOM.getNodeForLocation`으로 대상을 확인하고, 위험한 경우 즉시 명확한 에러로 거부합니다 (`multiple`/`size>1`/`disabled`는 실제로 팝업을 안 열어서 예외). 같은 위험이 있는 키보드 활성화 키(Space/Enter/화살표/Home/End/PageUp/PageDown)도 `browser_press_key`와 타이핑 중 스페이스 문자에서 동일하게 체크합니다. 전부 fail-closed.
- `browser_select_option`의 트러스티드 type-ahead가 한글 등 비-Latin 라벨("생산성")에서 빈 값을 선택해버리던 버그 수정. US-QWERTY 키 테이블이 비-ASCII 문자에 `windowsVirtualKeyCode: 0`을 줘서 Blink가 문자 입력으로 인식 못 하던 것을, 실제 브라우저가 IME 입력에 쓰는 `VK_PROCESSKEY(229)`로 대체.
- `Page.handleJavaScriptDialog` 실패를 조용히 삼키던 것을 1회 재시도 + 실패 시 로그로 변경.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets` (경고 없음)
- [x] `cargo test --workspace` (ab-browser 39개 unit test + ab-mcp 27개, 신규 로직 unit test 9개 포함)
- [x] 실기 검증: 실제 App Store Connect 페이지에서 `#primaryCategory` select를 `browser_select_option`으로 BUSINESS ↔ PRODUCTIVITY 왕복 성공 확인, 같은 select를 `browser_click`으로 직접 클릭 시 즉시 명확한 에러로 거부됨을 확인 (300초 hang 재현 안 됨)
- [ ] known gap: 키보드 쪽 체크는 top-level 페이지 포커스만 확인 — OOPIF(`browser_iframe_type`) 세션 내 포커스는 아직 커버 안 됨 (README에 명시)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>