### PR TITLE
release: v0.3.2 recover from a Chrome that exits under us

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ab-browser"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "ab-cdp",
  "anyhow",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "ab-cdp"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "futures-util",
  "serde",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "ab-mcp"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "ab-browser",
  "ab-cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/ab-cdp", "crates/ab-browser", "crates/ab-mcp"]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/crates/ab-browser/src/lib.rs
+++ b/crates/ab-browser/src/lib.rs
@@ -172,6 +172,15 @@ impl Browser {
         &self.client
     }
 
+    /// Whether the CDP transport to Chrome is still usable.
+    ///
+    /// A launched `Browser` whose Chrome has died keeps looking like a valid
+    /// handle — there is no reconnect path, so every later call fails. Callers
+    /// that supervise this process should treat `false` as "replace me".
+    pub fn is_connected(&self) -> bool {
+        self.client.is_connected()
+    }
+
     /// Launch Chrome and connect over CDP.
     ///
     /// Default mode is headful with a persistent profile. Browser-visible

--- a/crates/ab-cdp/src/lib.rs
+++ b/crates/ab-cdp/src/lib.rs
@@ -6,7 +6,7 @@
 //! `Runtime.enable` fingerprint that anti-bot systems watch for.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -45,6 +45,11 @@ type Pending = oneshot::Sender<Result<Value>>;
 
 struct Inner {
     next_id: AtomicU64,
+    /// Liveness of the underlying WebSocket. Set to `false` the moment the
+    /// reader task observes a close/error, or a write fails. Read with a
+    /// relaxed atomic load so health probes never contend on `sink`/`pending`
+    /// — a probe must not block behind an in-flight CDP request.
+    connected: AtomicBool,
     pending: Mutex<HashMap<u64, Pending>>,
     sink: Mutex<
         Option<
@@ -76,6 +81,7 @@ impl CdpClient {
 
         let inner = Arc::new(Inner {
             next_id: AtomicU64::new(1),
+            connected: AtomicBool::new(true),
             pending: Mutex::new(HashMap::new()),
             sink: Mutex::new(Some(sink)),
             events: events_tx,
@@ -96,6 +102,10 @@ impl CdpClient {
                     }
                 }
             }
+            // Chrome is gone (close frame, transport error, or EOF). Publish
+            // that fact before waking the waiters so anything that races the
+            // drain below already sees a disconnected client.
+            r.connected.store(false, Ordering::SeqCst);
             // Fail all outstanding requests on disconnect.
             let mut pending = r.pending.lock().await;
             for (_, tx) in pending.drain() {
@@ -104,6 +114,16 @@ impl CdpClient {
         });
 
         Ok(Self { inner })
+    }
+
+    /// Whether the CDP transport is still usable.
+    ///
+    /// Lock-free by design: health endpoints call this while a tool request
+    /// may be holding `sink`/`pending`, so it must never block. A `false`
+    /// here means Chrome is gone and every later request will fail — the
+    /// process needs a new browser, not a retry.
+    pub fn is_connected(&self) -> bool {
+        self.inner.connected.load(Ordering::SeqCst)
     }
 
     /// Subscribe to the raw CDP event stream.
@@ -138,6 +158,13 @@ impl CdpClient {
         params: Value,
         session_id: Option<&str>,
     ) -> Result<Value> {
+        // Fail fast once the reader task has seen the socket go away. Without
+        // this the write below reaches a dead tungstenite sink and surfaces as
+        // an opaque `Protocol("Trying to work with closed connection")`, which
+        // reads like a transient protocol hiccup instead of "Chrome is gone".
+        if !self.is_connected() {
+            return Err(CdpError::Closed);
+        }
         let id = self.inner.next_id.fetch_add(1, Ordering::SeqCst);
         let mut msg = json!({ "id": id, "method": method, "params": params });
         if let Some(sid) = session_id {
@@ -152,9 +179,15 @@ impl CdpClient {
             let sink = guard.as_mut().ok_or(CdpError::Closed)?;
             let text = serde_json::to_string(&msg)?;
             trace!("-> {text}");
-            sink.send(Message::Text(text))
-                .await
-                .map_err(|e| CdpError::Protocol(e.to_string()))?;
+            if let Err(e) = sink.send(Message::Text(text)).await {
+                // A write failure means the socket is unusable even if the
+                // reader task has not observed the close yet. Latch it so the
+                // next caller (and any health probe) sees the truth.
+                self.inner.connected.store(false, Ordering::SeqCst);
+                self.inner.pending.lock().await.remove(&id);
+                debug!("cdp write failed, marking transport closed: {e}");
+                return Err(CdpError::Closed);
+            }
         }
 
         match tokio::time::timeout(self.inner.request_timeout, rx).await {
@@ -199,5 +232,22 @@ async fn dispatch(inner: &Arc<Inner>, txt: &str) {
         };
         debug!("event {} (session={:?})", ev.method, ev.session_id);
         let _ = inner.events.send(ev);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Supervisors (clawgram, negotium) pattern-match this string to tell
+    /// "Chrome is gone, replace the process" apart from a retryable hiccup.
+    /// Renaming it silently breaks their crash detection, so pin it here.
+    #[test]
+    fn closed_transport_error_is_stable_and_distinct() {
+        assert_eq!(CdpError::Closed.to_string(), "transport closed");
+        assert_ne!(
+            CdpError::Closed.to_string(),
+            CdpError::Protocol("Trying to work with closed connection".into()).to_string(),
+        );
     }
 }

--- a/crates/ab-mcp/src/main.rs
+++ b/crates/ab-mcp/src/main.rs
@@ -23,7 +23,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{info, warn};
 
 mod http_security;
 mod secret_broker;
@@ -246,6 +246,11 @@ struct State {
     /// Durable ownership for every page; one owner may have multiple tabs.
     page_owners: HashMap<String, String>,
     next: u64,
+    /// Set when a dead browser was reaped, cleared when a fresh one launches.
+    /// Sticky on purpose: the reap nulls out `browser`, so without this the
+    /// very next call could no longer tell "Chrome died and took your pages"
+    /// apart from "you passed a bad page id".
+    browser_lost: bool,
 }
 
 #[derive(Clone)]
@@ -803,6 +808,53 @@ impl BrowserServer {
         Ok(())
     }
 
+    /// Discard a browser whose CDP transport has died, along with every page
+    /// handle that belonged to it.
+    ///
+    /// Chrome can exit under us (crash, OOM kill, user quit) while this
+    /// process keeps running. There is no CDP reconnect: the old `Browser` is
+    /// permanently unusable, and so is every `Page` cloned from it. Leaving
+    /// them in `State` is what made this state unrecoverable — callers kept
+    /// getting `transport closed` from handles that could never work again,
+    /// and nothing ever replaced the browser.
+    ///
+    /// Returns whether a dead browser was reaped, so callers can tell a
+    /// cold start apart from a recovery.
+    fn reap_dead_browser(st: &mut State) -> bool {
+        if st
+            .browser
+            .as_ref()
+            .is_none_or(ab_browser::Browser::is_connected)
+        {
+            return false;
+        }
+        let lost_pages = st.pages.len();
+        st.pages.clear();
+        st.owners.clear();
+        st.page_owners.clear();
+        // Drop without `close()`: Chrome is already gone, so the shutdown
+        // handshake would just block on the dead socket.
+        st.browser = None;
+        st.browser_lost = true;
+        warn!("cdp transport lost; discarded dead browser and {lost_pages} page handle(s)");
+        true
+    }
+
+    /// Error for a page id that cannot be resolved.
+    ///
+    /// Distinguishes "you passed a bad id" from "the browser died and took
+    /// every page with it" — the second one is actionable (re-navigate) and
+    /// used to surface as an opaque transport error.
+    fn unresolved_page_error(st: &State, id: &str) -> McpError {
+        if st.browser_lost || st.browser.as_ref().is_some_and(|b| !b.is_connected()) {
+            return fail(format!(
+                "browser was lost (chrome exited); page '{id}' and every other \
+                 page handle are gone. Call browser_navigate to start a fresh browser."
+            ));
+        }
+        fail(format!("unknown page or owner '{id}'"))
+    }
+
     fn resolve_page_id(st: &State, id_or_owner: &str) -> Option<String> {
         if let Some(owner) = request_owner() {
             if id_or_owner == owner {
@@ -822,16 +874,18 @@ impl BrowserServer {
 
     /// Resolve either a concrete page id or a claimed owner alias.
     async fn canonical_page_id(&self, id_or_owner: &str) -> Result<String, McpError> {
-        let st = self.state.lock().await;
+        let mut st = self.state.lock().await;
+        Self::reap_dead_browser(&mut st);
         Self::resolve_page_id(&st, id_or_owner)
-            .ok_or_else(|| fail(format!("unknown page or owner '{id_or_owner}'")))
+            .ok_or_else(|| Self::unresolved_page_error(&st, id_or_owner))
     }
 
     /// Clone the Page for a given id/owner (does not hold the lock across ops).
     async fn page_of(&self, id: &str) -> Result<Page, McpError> {
-        let st = self.state.lock().await;
-        let page_id = Self::resolve_page_id(&st, id)
-            .ok_or_else(|| fail(format!("unknown page or owner '{id}'")))?;
+        let mut st = self.state.lock().await;
+        Self::reap_dead_browser(&mut st);
+        let page_id =
+            Self::resolve_page_id(&st, id).ok_or_else(|| Self::unresolved_page_error(&st, id))?;
         st.pages
             .get(&page_id)
             .map(|e| e.page.clone())
@@ -843,8 +897,9 @@ impl BrowserServer {
         id: &str,
     ) -> Result<(String, Page, Arc<CancellationToken>), McpError> {
         let mut st = self.state.lock().await;
-        let page_id = Self::resolve_page_id(&st, id)
-            .ok_or_else(|| fail(format!("unknown page or owner '{id}'")))?;
+        Self::reap_dead_browser(&mut st);
+        let page_id =
+            Self::resolve_page_id(&st, id).ok_or_else(|| Self::unresolved_page_error(&st, id))?;
         let entry = st
             .pages
             .get_mut(&page_id)
@@ -873,9 +928,10 @@ impl BrowserServer {
     }
 
     async fn element_ref_of(&self, id: &str, ref_: &str) -> Result<ElementRef, McpError> {
-        let st = self.state.lock().await;
-        let page_id = Self::resolve_page_id(&st, id)
-            .ok_or_else(|| fail(format!("unknown page or owner '{id}'")))?;
+        let mut st = self.state.lock().await;
+        Self::reap_dead_browser(&mut st);
+        let page_id =
+            Self::resolve_page_id(&st, id).ok_or_else(|| Self::unresolved_page_error(&st, id))?;
         let entry = st
             .pages
             .get(&page_id)
@@ -1040,7 +1096,9 @@ impl BrowserServer {
     /// Import tabs created by page JavaScript or target=_blank into the MCP page map.
     async fn sync_external_pages(&self) -> Result<Vec<String>, McpError> {
         let mut st = self.state.lock().await;
-        let Some(browser) = st.browser.as_ref() else {
+        let Some(browser) = st.browser.as_ref().filter(|b| b.is_connected()) else {
+            // No browser, or one whose transport is gone. Either way there are
+            // no external tabs to import; `open_page` owns the recovery.
             return Ok(Vec::new());
         };
         let targets = browser.page_targets().await.map_err(fail)?;
@@ -1150,8 +1208,17 @@ impl BrowserServer {
     /// register it. Returns (page_id, snapshot_text).
     async fn open_page(&self, url: &str) -> Result<(String, String), McpError> {
         let mut st = self.state.lock().await;
+        // Recover from a Chrome that exited under us. `browser_navigate` is the
+        // one tool that does not need a pre-existing page, which makes it the
+        // natural re-entry point: an agent that hits `transport closed` can get
+        // a working browser back by navigating, with no supervisor involvement.
+        let recovered = Self::reap_dead_browser(&mut st);
         if st.browser.is_none() {
             st.browser = Some(make_browser().await.map_err(fail)?);
+            st.browser_lost = false;
+            if recovered {
+                warn!("relaunched chrome after transport loss");
+            }
         }
         // Blank page first so the network log captures the navigation itself.
         let page = st
@@ -2166,7 +2233,10 @@ impl BrowserServer {
     #[tool(description = "Browser status: running, mode, open pages")]
     async fn browser_status(&self) -> Result<CallToolResult, McpError> {
         let st = self.state.lock().await;
-        let running = st.browser.is_some();
+        let running = st
+            .browser
+            .as_ref()
+            .is_some_and(ab_browser::Browser::is_connected);
         let open_pages = request_owner().map_or_else(
             || st.pages.len(),
             |owner| {
@@ -2976,6 +3046,37 @@ mod tests {
             .await;
     }
 
+    /// A Chrome that exits mid-session used to leave every page handle in
+    /// place, so the next call failed with a raw `transport closed`. The reap
+    /// must clear those handles and latch a marker that survives nulling out
+    /// `browser`, otherwise the follow-up error cannot explain itself.
+    #[test]
+    fn reaping_is_a_no_op_without_a_browser() {
+        let mut state = State::default();
+        state.pages.clear();
+        assert!(!BrowserServer::reap_dead_browser(&mut state));
+        assert!(!state.browser_lost);
+    }
+
+    #[test]
+    fn lost_browser_marker_explains_stale_page_ids() {
+        let mut state = State::default();
+        // Plain bad id while the browser is fine.
+        let normal = BrowserServer::unresolved_page_error(&state, "p1").to_string();
+        assert!(
+            normal.contains("unknown page or owner"),
+            "expected the generic message, got: {normal}"
+        );
+
+        // Same id after Chrome died: actionable, and names the recovery call.
+        state.browser_lost = true;
+        let lost = BrowserServer::unresolved_page_error(&state, "p1").to_string();
+        assert!(
+            lost.contains("browser was lost") && lost.contains("browser_navigate"),
+            "expected the recovery hint, got: {lost}"
+        );
+    }
+
     #[tokio::test]
     async fn scoped_page_resolution_blocks_other_owners_for_activation_and_wheel() {
         let mut state = State::default();
@@ -3496,10 +3597,53 @@ async fn sse_post(
     StatusCode::ACCEPTED
 }
 
+/// Liveness for supervisors.
+///
+/// `ok` intentionally reports only that this HTTP server is up — existing
+/// consumers (clawgram, negotium) gate spawn readiness on it and must not
+/// start seeing `false` for a browser-level fault. The browser's real state
+/// is additive under `browser`, so a supervisor can distinguish the two
+/// failure classes that used to look identical:
+///
+///   * process dead        -> the request itself fails
+///   * process up, Chrome gone -> `ok:true` + `browser.connected:false`
+///
+/// The second case is the one that used to be unrecoverable: MCP `initialize`
+/// still succeeds, so a transport-level probe reports healthy while every
+/// browser tool fails against a closed CDP socket.
+///
+/// `try_lock` is deliberate. The browser mutex is held for the duration of an
+/// in-flight tool call (navigations can run for tens of seconds), and a health
+/// endpoint that blocks behind it would report a timeout — causing exactly the
+/// spurious restarts this is meant to prevent. A contended lock means a tool
+/// call is actively running, which is itself evidence the browser is alive.
 async fn health(
     axum::extract::State(state): axum::extract::State<SseState>,
 ) -> axum::Json<serde_json::Value> {
-    axum::Json(state.security.health())
+    let mut payload = state.security.health();
+    let browser = match state.browser.try_lock() {
+        Ok(st) => match st.browser.as_ref() {
+            Some(browser) => serde_json::json!({
+                "launched": true,
+                "connected": browser.is_connected(),
+                "pages": st.pages.len(),
+            }),
+            None => serde_json::json!({
+                "launched": false,
+                "connected": false,
+                "pages": 0,
+            }),
+        },
+        Err(_) => serde_json::json!({
+            "launched": true,
+            "connected": true,
+            "busy": true,
+        }),
+    };
+    if let Some(map) = payload.as_object_mut() {
+        map.insert("browser".to_string(), browser);
+    }
+    axum::Json(payload)
 }
 
 async fn close_owner_pages(


### PR DESCRIPTION
## Problem

A Chrome that died mid-session left this process in a state no supervisor could detect or repair.

The CDP reader task drained pending requests on disconnect but left `sink` as `Some`, so every later write reached a dead tungstenite socket and surfaced as `Protocol("Trying to work with closed connection")` — indistinguishable from a transient hiccup. Nothing recorded that the transport was gone, `/health` answered a hardcoded `ok:true`, and MCP `initialize` kept succeeding, so transport-level probes reported the server healthy while every browser tool failed.

There was no reconnect path, so the condition was permanent. `make_browser()` had exactly one call site guarded by `if st.browser.is_none()`, and a dead Chrome leaves `st.browser` as `Some(...)` — that branch could never be reached again.

Observed in production: an agent burned three turns on kill/relaunch cycles before abandoning a shared browser profile that ~50 topics depended on, losing its login state in the process.

## Changes

**`ab-cdp`** — latch an `AtomicBool` the moment the reader task sees a close/error or a write fails, expose it as `CdpClient::is_connected()`, and fail fast with `CdpError::Closed` instead of an opaque protocol error. The flag is read with a plain atomic load so health probes never contend on `sink`/`pending`.

**`ab-browser`** — `Browser::is_connected()` delegates to the client.

**`ab-mcp`** — `/health` now reports `browser.{launched,connected,pages}` alongside the existing fields.

- `ok` is deliberately unchanged. Downstream supervisors (clawgram, negotium) gate spawn readiness on it and must not start seeing `false` for a browser-level fault. `ok` means "this HTTP server is up"; `browser.connected` means "CDP is alive".
- Reading uses `try_lock`, because the browser mutex is held across in-flight tool calls and blocking here would time out the probe and cause the very restarts this prevents. A contended lock means a tool is running, which is itself evidence the browser is alive.

**Self-healing** — `open_page` reaps a disconnected browser (dropped without the `close()` handshake, since Chrome is already gone) and launches a fresh one, making `browser_navigate` the recovery entry point. Page handles belong to the dead Chrome and are purged with it. A sticky `browser_lost` marker survives nulling out `browser`, so the first stale-handle call explains itself and names the recovery call; it clears once a new browser is up.

## Before / after

| | before | after |
|---|---|---|
| `/health`, Chrome dead | `ok:true` — byte-identical to healthy | `ok:true` + `browser.connected:false` |
| tool call, CDP dead | `cdp protocol error: Trying to work with closed connection` | `cdp: transport closed` |
| stale page handle | same opaque error | `browser was lost (chrome exited); page 'p1' ... Call browser_navigate to start a fresh browser.` |
| unknown page id | `unknown page or owner 'p99'` | unchanged |
| recovery | none — permanent | `browser_navigate` relaunches |

## Verification

Replayed the production scenario against a server isolated on a spare port and temp profile:

1. navigate → `{launched:true, connected:true, pages:1}`
2. SIGKILL Chrome only, server survives → `{launched:true, connected:false, pages:1}`
3. MCP `initialize` **still succeeds** — this is the trap that made transport-level probes report healthy
4. stale handle `p1` → explains itself and names the recovery call
5. `browser_navigate` → new Chrome, page `p2`, health back to `connected:true`
6. unknown id `p99` → generic error again, confirming the marker clears

Local run of every CI step: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build --release --workspace`, `cargo test --workspace` (69 passed), `node bench/run.mjs` (16/16 native surfaces intact).

Three regression tests added: the `CdpError::Closed` string contract (supervisors pattern-match it), reap as a no-op without a browser, and the `browser_lost` message branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)