### PR TITLE
release: v0.3.3 recover a lost page through browser_navigate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ab-browser"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "ab-cdp",
  "anyhow",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "ab-cdp"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "futures-util",
  "serde",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "ab-mcp"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "ab-browser",
  "ab-cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/ab-cdp", "crates/ab-browser", "crates/ab-mcp"]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/crates/ab-mcp/src/main.rs
+++ b/crates/ab-mcp/src/main.rs
@@ -840,6 +840,13 @@ impl BrowserServer {
         true
     }
 
+    /// Whether the last page resolution failed because Chrome went away, as
+    /// opposed to the caller naming a page that never existed. Cleared when a
+    /// fresh browser launches, so it only ever reports the current loss.
+    async fn browser_was_lost(&self) -> bool {
+        self.state.lock().await.browser_lost
+    }
+
     /// Error for a page id that cannot be resolved.
     ///
     /// Distinguishes "you passed a bad id" from "the browser died and took
@@ -1280,12 +1287,28 @@ impl BrowserServer {
         Parameters(a): Parameters<NavigateArgs>,
     ) -> Result<CallToolResult, McpError> {
         if let Some(pid) = &a.page {
-            let page = self.page_of(pid).await?;
-            page.navigate(&a.url).await.map_err(fail)?;
-            let snap = page.snapshot().await.map_err(fail)?;
-            self.store_snapshot(pid, snap.refs.clone(), snap.text.clone())
-                .await;
-            return Ok(ok(format!("page {pid}\nurl {}\n\n{}", a.url, snap.text)));
+            // A named page that no longer exists is usually a caller mistake,
+            // but it is also what every handle looks like after Chrome exits.
+            // In that second case the intent — "put this URL on screen" — is
+            // still satisfiable, and telling the caller to invoke
+            // `browser_navigate` when they just did is a wasted round trip.
+            // Fall through to opening a fresh tab; a genuinely unknown page id
+            // (no browser loss) still errors.
+            match self.page_of(pid).await {
+                Ok(page) => {
+                    page.navigate(&a.url).await.map_err(fail)?;
+                    let snap = page.snapshot().await.map_err(fail)?;
+                    self.store_snapshot(pid, snap.refs.clone(), snap.text.clone())
+                        .await;
+                    return Ok(ok(format!("page {pid}\nurl {}\n\n{}", a.url, snap.text)));
+                }
+                Err(err) => {
+                    if !self.browser_was_lost().await {
+                        return Err(err);
+                    }
+                    warn!("page '{pid}' was lost with the browser; opening a fresh tab");
+                }
+            }
         }
         let (id, text) = self.open_page(&a.url).await?;
         Ok(ok(format!("page {id}\nurl {}\n\n{}", a.url, text)))
@@ -3003,6 +3026,8 @@ mod tests {
         DEFAULT_MAX_OUTPUT_LIMIT, REQUEST_OWNER,
     };
     use rmcp::model::CallToolRequestParams;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
 
     #[test]
     fn capability_comparison_requires_an_exact_match() {
@@ -3044,6 +3069,23 @@ mod tests {
                 assert!(enforce_scoped_owner("other-owner", "release").is_err());
             })
             .await;
+    }
+
+    /// `browser_navigate` recovers a lost page by opening a fresh tab, but only
+    /// when the browser is what went missing. A merely wrong page id must keep
+    /// erroring, or a typo would silently discard the caller's tab.
+    #[tokio::test]
+    async fn lost_browser_is_distinguishable_from_a_bad_page_id() {
+        let state = Arc::new(Mutex::new(State::default()));
+        let server = BrowserServer::with_state_and_broker(state.clone(), None, None);
+
+        assert!(
+            !server.browser_was_lost().await,
+            "a healthy server must not claim the browser was lost"
+        );
+
+        state.lock().await.browser_lost = true;
+        assert!(server.browser_was_lost().await);
     }
 
     /// A Chrome that exits mid-session used to leave every page handle in


### PR DESCRIPTION
## Gap left by v0.3.2

v0.3.2 relaunches Chrome when a tool needs a browser and finds the CDP transport gone — but only `open_page` does that, and `browser_navigate` only reaches `open_page` when **no `page` argument** is given.

So `browser_navigate({url, page: "p1"})` after Chrome exits resolved `p1`, found it reaped, and answered:

```
browser was lost (chrome exited); page 'p1' ... Call browser_navigate to start a fresh browser.
```

…instructing the caller to do the thing they just did. Naming the page you were working in is the natural way to continue, so the most likely recovery attempt was the one that did not recover — costing an extra round trip on a path that exists to save one.

## Fix

Fall through to `open_page` when page resolution fails **because the browser was lost**. The intent — put this URL on screen — is still satisfiable, and a fresh tab is the honest degradation once the old one is provably gone.

Gated on the `browser_lost` marker rather than on resolution failing at all: a genuinely unknown page id still errors. Without that distinction a typo would silently abandon the caller's real tab and open a new one.

## Recovery coverage after this change

| call | before | after |
|---|---|---|
| `browser_navigate({url})` | relaunches | relaunches |
| `browser_new_page` | relaunches | relaunches |
| `browser_navigate({url, page})` | error telling you to call `browser_navigate` | **relaunches** |
| `browser_snapshot` / `click` / `type` / … | actionable error | actionable error (correct — the page it wants is gone, so there is nothing to act on) |

## Verified

Against a server whose Chrome was SIGKILLed while the engine stayed up:

1. `browser_navigate({url, page:"p1"})` → returns fresh `p2`, `browser.connected` back to `true`
2. `browser_navigate({url, page:"p99"})` on a healthy browser → still `unknown page or owner 'p99'`

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings` (0 warnings), `cargo test` (71 pass), `node bench/run.mjs` 16/16 native surfaces intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)