### PR TITLE
v0.3.5: invalidate stalled CDP transports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ab-browser"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "ab-cdp",
  "anyhow",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "ab-cdp"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "futures-util",
  "serde",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "ab-mcp"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "ab-browser",
  "ab-cdp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/ab-cdp", "crates/ab-browser", "crates/ab-mcp"]
 
 [workspace.package]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/crates/ab-cdp/Cargo.toml
+++ b/crates/ab-cdp/Cargo.toml
@@ -14,3 +14,6 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/ab-cdp/src/lib.rs
+++ b/crates/ab-cdp/src/lib.rs
@@ -14,6 +14,7 @@ use futures_util::{SinkExt, StreamExt};
 use serde::de::DeserializeOwned;
 use serde_json::{json, Value};
 use tokio::sync::{broadcast, oneshot, Mutex};
+use tokio::time::{timeout_at, Instant};
 use tokio_tungstenite::tungstenite::Message;
 use tracing::{debug, trace, warn};
 
@@ -42,27 +43,58 @@ pub struct CdpEvent {
 }
 
 type Pending = oneshot::Sender<Result<Value>>;
+type CdpSink = futures_util::stream::SplitSink<
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+    Message,
+>;
 
 struct Inner {
     next_id: AtomicU64,
     /// Liveness of the underlying WebSocket. Set to `false` the moment the
-    /// reader task observes a close/error, or a write fails. Read with a
-    /// relaxed atomic load so health probes never contend on `sink`/`pending`
-    /// — a probe must not block behind an in-flight CDP request.
+    /// reader task observes a close/error, a write fails, or a request times
+    /// out. Read atomically so health probes never contend on `sink`/`pending`
+    /// -- a probe must not block behind an in-flight CDP request.
     connected: AtomicBool,
     pending: Mutex<HashMap<u64, Pending>>,
-    sink: Mutex<
-        Option<
-            futures_util::stream::SplitSink<
-                tokio_tungstenite::WebSocketStream<
-                    tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-                >,
-                Message,
-            >,
-        >,
-    >,
+    sink: Mutex<Option<CdpSink>>,
     events: broadcast::Sender<CdpEvent>,
     request_timeout: Duration,
+}
+
+impl Inner {
+    /// Permanently invalidate this transport and wake every registered request.
+    ///
+    /// `held_sink` lets a sender reuse the same operation without reacquiring a
+    /// lock it already owns. Other callers only try the sink lock: invalidation
+    /// must never become a new unbounded wait behind a stalled writer.
+    async fn invalidate(self: &Arc<Self>, held_sink: Option<&mut Option<CdpSink>>) {
+        {
+            let mut pending = self.pending.lock().await;
+            self.connected.store(false, Ordering::SeqCst);
+            for (_, tx) in pending.drain() {
+                let _ = tx.send(Err(CdpError::Closed));
+            }
+        }
+
+        match held_sink {
+            Some(sink) => {
+                sink.take();
+            }
+            None => {
+                if let Ok(mut sink) = self.sink.try_lock() {
+                    sink.take();
+                } else {
+                    // Cleanup must not delay the caller, but the sink should
+                    // still be released once the current writer leaves its
+                    // critical section.
+                    let inner = Arc::clone(self);
+                    tokio::spawn(async move {
+                        inner.sink.lock().await.take();
+                    });
+                }
+            }
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -103,24 +135,7 @@ impl CdpClient {
                 }
             }
             // Chrome is gone (close frame, transport error, or EOF).
-            //
-            // Publish the disconnection *while holding `pending`*. A sender
-            // checks `connected` under the same lock before registering, so
-            // every request either lands before this drain and is woken here,
-            // or observes the closed flag and fails immediately. Storing the
-            // flag outside the lock left a window where a waiter was inserted
-            // after the drain and then slept until the 30s request timeout.
-            {
-                let mut pending = r.pending.lock().await;
-                r.connected.store(false, Ordering::SeqCst);
-                for (_, tx) in pending.drain() {
-                    let _ = tx.send(Err(CdpError::Closed));
-                }
-            }
-            // Release the dead sink. Keeping it as `Some` meant later writes
-            // reached a closed socket and produced a transport-level error in
-            // place of a clear `Closed`.
-            r.sink.lock().await.take();
+            r.invalidate(None).await;
         });
 
         Ok(Self { inner })
@@ -133,8 +148,8 @@ impl CdpClient {
     /// here means Chrome is gone and every later request will fail — the
     /// process needs a new browser, not a retry.
     ///
-    /// The load is `SeqCst` to stay ordered against the reader task, which
-    /// publishes the disconnection under the `pending` lock.
+    /// The load is `SeqCst` to stay ordered against transport invalidation,
+    /// which publishes the disconnection under the `pending` lock.
     pub fn is_connected(&self) -> bool {
         self.inner.connected.load(Ordering::SeqCst)
     }
@@ -171,6 +186,10 @@ impl CdpClient {
         params: Value,
         session_id: Option<&str>,
     ) -> Result<Value> {
+        // One deadline covers queueing for the shared writer, writing the
+        // command, and waiting for Chrome's response. Starting a fresh timeout
+        // only after `sink.send()` allowed a blocked writer to hang forever.
+        let deadline = Instant::now() + self.inner.request_timeout;
         let id = self.inner.next_id.fetch_add(1, Ordering::SeqCst);
         let mut msg = json!({ "id": id, "method": method, "params": params });
         if let Some(sid) = session_id {
@@ -191,34 +210,70 @@ impl CdpClient {
         }
 
         {
-            let mut guard = self.inner.sink.lock().await;
-            let sink = guard.as_mut().ok_or(CdpError::Closed)?;
+            let mut guard = match timeout_at(deadline, self.inner.sink.lock()).await {
+                Ok(guard) => guard,
+                Err(_) => {
+                    warn!(
+                        request_id = id,
+                        method,
+                        session_id,
+                        timeout_ms = self.inner.request_timeout.as_millis() as u64,
+                        phase = "writer-lock",
+                        "cdp request timed out; invalidating transport"
+                    );
+                    self.inner.invalidate(None).await;
+                    return Err(CdpError::Timeout(self.inner.request_timeout));
+                }
+            };
+            if !self.inner.connected.load(Ordering::SeqCst) {
+                return Err(CdpError::Closed);
+            }
+            let Some(sink) = guard.as_mut() else {
+                self.inner.invalidate(Some(&mut *guard)).await;
+                return Err(CdpError::Closed);
+            };
             let text = serde_json::to_string(&msg)?;
             trace!("-> {text}");
-            if let Err(e) = sink.send(Message::Text(text)).await {
-                // A write failure means the socket is unusable even if the
-                // reader task has not observed the close yet. Latch it and
-                // wake *every* waiter: the reader may never see an EOF on a
-                // half-open socket, so leaving the others registered would
-                // park them until the 30s timeout each.
-                {
-                    let mut pending = self.inner.pending.lock().await;
-                    self.inner.connected.store(false, Ordering::SeqCst);
-                    for (_, waiter) in pending.drain() {
-                        let _ = waiter.send(Err(CdpError::Closed));
-                    }
+            match timeout_at(deadline, sink.send(Message::Text(text))).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    // A write failure means the socket is unusable even if the
+                    // reader task has not observed the close yet.
+                    self.inner.invalidate(Some(&mut *guard)).await;
+                    debug!("cdp write failed, marking transport closed: {e}");
+                    return Err(CdpError::Closed);
                 }
-                *guard = None;
-                debug!("cdp write failed, marking transport closed: {e}");
-                return Err(CdpError::Closed);
+                Err(_) => {
+                    warn!(
+                        request_id = id,
+                        method,
+                        session_id,
+                        timeout_ms = self.inner.request_timeout.as_millis() as u64,
+                        phase = "write",
+                        "cdp request timed out; invalidating transport"
+                    );
+                    self.inner.invalidate(Some(&mut *guard)).await;
+                    return Err(CdpError::Timeout(self.inner.request_timeout));
+                }
             }
         }
 
-        match tokio::time::timeout(self.inner.request_timeout, rx).await {
+        match timeout_at(deadline, rx).await {
             Ok(Ok(res)) => res,
             Ok(Err(_)) => Err(CdpError::Closed),
             Err(_) => {
-                self.inner.pending.lock().await.remove(&id);
+                // An unanswered command means this transport can no longer be
+                // trusted. Invalidate every shared client instead of leaving
+                // them attached to a half-open socket.
+                warn!(
+                    request_id = id,
+                    method,
+                    session_id,
+                    timeout_ms = self.inner.request_timeout.as_millis() as u64,
+                    phase = "response",
+                    "cdp request timed out; invalidating transport"
+                );
+                self.inner.invalidate(None).await;
                 Err(CdpError::Timeout(self.inner.request_timeout))
             }
         }
@@ -262,6 +317,9 @@ async fn dispatch(inner: &Arc<Inner>, txt: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::net::TcpListener;
+    use tokio::sync::mpsc;
+    use tokio_tungstenite::accept_async;
 
     /// Supervisors (clawgram, negotium) pattern-match this string to tell
     /// "Chrome is gone, replace the process" apart from a retryable hiccup.
@@ -273,5 +331,107 @@ mod tests {
             CdpError::Closed.to_string(),
             CdpError::Protocol("Trying to work with closed connection".into()).to_string(),
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn request_timeout_invalidates_transport_and_releases_all_waiters() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (request_tx, mut requests) = mpsc::unbounded_channel();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut websocket = accept_async(stream).await.unwrap();
+            while let Some(message) = websocket.next().await {
+                if message.unwrap().is_text() {
+                    request_tx.send(()).unwrap();
+                }
+            }
+        });
+
+        let client = CdpClient::connect(&format!("ws://{addr}")).await.unwrap();
+        let (waiter_one_tx, waiter_one_rx) = oneshot::channel();
+        let (waiter_two_tx, waiter_two_rx) = oneshot::channel();
+        {
+            let mut pending = client.inner.pending.lock().await;
+            pending.insert(10_001, waiter_one_tx);
+            pending.insert(10_002, waiter_two_tx);
+        }
+
+        let first_client = client.clone();
+        let first = tokio::spawn(async move { first_client.send("Test.first", json!({})).await });
+        requests.recv().await.unwrap();
+        drop(client.inner.sink.lock().await);
+
+        tokio::time::advance(Duration::from_secs(30)).await;
+        tokio::task::yield_now().await;
+
+        assert!(matches!(
+            first.await.unwrap(),
+            Err(CdpError::Timeout(duration)) if duration == Duration::from_secs(30)
+        ));
+        assert!(matches!(
+            waiter_one_rx.await.unwrap(),
+            Err(CdpError::Closed)
+        ));
+        assert!(matches!(
+            waiter_two_rx.await.unwrap(),
+            Err(CdpError::Closed)
+        ));
+        assert!(!client.is_connected());
+        assert!(client.inner.pending.lock().await.is_empty());
+        assert!(client.inner.sink.lock().await.is_none());
+        assert!(matches!(
+            client.send("Test.later", json!({})).await,
+            Err(CdpError::Closed)
+        ));
+
+        server.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn writer_lock_timeout_returns_without_waiting_for_the_lock_holder() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut websocket = accept_async(stream).await.unwrap();
+            while websocket.next().await.is_some() {}
+        });
+
+        let client = CdpClient::connect(&format!("ws://{addr}")).await.unwrap();
+        let sink_guard = client.inner.sink.lock().await;
+        let blocked_client = client.clone();
+        let blocked =
+            tokio::spawn(async move { blocked_client.send("Test.blocked", json!({})).await });
+
+        // Wait until the request is registered and blocked on the held writer
+        // lock before advancing its single end-to-end deadline.
+        loop {
+            if !client.inner.pending.lock().await.is_empty() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        tokio::time::advance(Duration::from_secs(30)).await;
+        tokio::task::yield_now().await;
+
+        assert!(matches!(
+            blocked.await.unwrap(),
+            Err(CdpError::Timeout(duration)) if duration == Duration::from_secs(30)
+        ));
+        assert!(!client.is_connected());
+        assert!(client.inner.pending.lock().await.is_empty());
+
+        // Invalidation returns before this guard is released. Its detached
+        // cleanup then removes the sink as soon as the holder exits.
+        drop(sink_guard);
+        tokio::task::yield_now().await;
+        assert!(client.inner.sink.lock().await.is_none());
+        assert!(matches!(
+            client.send("Test.later", json!({})).await,
+            Err(CdpError::Closed)
+        ));
+
+        server.abort();
     }
 }


### PR DESCRIPTION
## Summary
- enforce one 30-second deadline across writer lock, WebSocket write, and response wait
- invalidate timed-out transports, wake all pending callers, and make health report disconnected
- avoid blocking invalidation behind a stalled writer
- add deterministic response-timeout and writer-lock contention tests

## Verification
- cargo fmt --check
- git diff --check
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features -- -D warnings