### PR TITLE
v0.4.0: isolate shared browser profile failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,13 @@ version = 4
 
 [[package]]
 name = "ab-browser"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "ab-cdp",
  "anyhow",
  "base64",
+ "fs2",
+ "nix",
  "rand 0.8.7",
  "rand_distr",
  "reqwest",
@@ -24,24 +26,27 @@ dependencies = [
 
 [[package]]
 name = "ab-cdp"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
+ "arc-swap",
  "futures-util",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
+ "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "ab-mcp"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "ab-browser",
  "ab-cdp",
  "anyhow",
+ "arc-swap",
  "axum",
  "futures",
  "hmac",
@@ -82,6 +87,15 @@ name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "async-trait"
@@ -373,6 +387,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -848,6 +872,18 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -1960,6 +1996,28 @@ checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/ab-cdp", "crates/ab-browser", "crates/ab-mcp"]
 
 [workspace.package]
-version = "0.3.5"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -34,6 +34,9 @@ tempfile = "3"
 rmcp = { version = "2.2", features = ["server", "transport-io", "transport-streamable-http-server"] }
 schemars = "1"
 axum = "0.8"
+fs2 = "0.4"
+arc-swap = "1"
+nix = { version = "0.30", features = ["signal", "process"] }
 
 [profile.release]
 lto = "thin"

--- a/README.md
+++ b/README.md
@@ -527,6 +527,53 @@ browsers are always left untouched.
 `AB_HTTP_CAPABILITY` protects HTTP/SSE requests with `X-Browser-Capability`
 and is required for non-loopback binds.
 
+## Browser lifecycle and health
+
+Version 0.4 keeps an OS-level exclusive lock at `<profile>/.browser-rs.lock`
+for every Chrome it launches. A second process receives `profile_busy`; it
+never deletes Chrome `Singleton*` ownership files. Chrome itself performs stale
+singleton recovery after browser-rs verifies that no recorded process is live.
+
+`GET /health` is lock-free and returns schema 2 lifecycle data. Browser states
+are `absent`, `launching`, `ready`, `suspect`, `dead`, and `draining`.
+`generation` increases after each successful Chrome launch, while `spawnNonce`
+identifies the browser-rs process itself. Supervisors must compare both values
+before acting on an old probe result.
+
+```json
+{
+  "ok": true,
+  "schema": 2,
+  "spawnNonce": "...",
+  "process": { "pid": 4242, "draining": false },
+  "browser": {
+    "state": "ready",
+    "generation": 3,
+    "launched": true,
+    "connected": true,
+    "chromePid": 4300,
+    "pages": 4,
+    "lastTransportError": null
+  },
+  "pages": { "total": 4, "stalled": 0 },
+  "inflight": { "tools": 2 },
+  "recovery": { "inProgress": false, "attemptsInWindow": 0, "cooldownUntilMs": null }
+}
+```
+
+Session-scoped response timeouts mark only the affected page as stalled and
+run a five-second browser probe. EOF, write failure, writer-lock timeout, or a
+failed probe marks the transport dead. Recovery is single-flight and limited
+to three attempts per ten minutes, followed by a five-minute circuit-open
+period.
+
+Administrative HTTP operations require the root `X-Browser-Capability`:
+
+- `POST /admin/relaunch?expected_generation=N` replaces Chrome only when the
+  supplied generation still matches; stale requests receive HTTP 409.
+- `POST /admin/drain` rejects future launches and closes the owned Chrome so a
+  process supervisor can replace browser-rs without a competing relaunch.
+
 Managed hosts (see [Managed mode](#managed-mode-secure-multi-tenant-hosting)
 above) can set:
 

--- a/crates/ab-browser/Cargo.toml
+++ b/crates/ab-browser/Cargo.toml
@@ -19,6 +19,10 @@ reqwest.workspace = true
 base64.workspace = true
 rand.workspace = true
 rand_distr.workspace = true
+fs2.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+nix.workspace = true
 
 [dev-dependencies]
 tracing-subscriber.workspace = true

--- a/crates/ab-browser/src/lib.rs
+++ b/crates/ab-browser/src/lib.rs
@@ -5,6 +5,7 @@
 //! can run the loop: `snapshot -> act -> verify`.
 
 pub mod pointer;
+mod profile_lock;
 pub mod snapshot;
 pub mod stealth;
 
@@ -15,14 +16,16 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use ab_cdp::CdpClient;
+use ab_cdp::{CdpClient, CdpEvent};
 use rand::thread_rng;
 use rand_distr::{Binomial, Distribution, LogNormal, Normal};
 use serde::Serialize;
 use serde_json::{json, Value};
 use tokio::process::{Child, Command};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
+
+use profile_lock::ProfileLock;
 
 pub use pointer::{PointerAction, PointerLocation, PointerOutcome, PointerRequest};
 pub use snapshot::{DocumentIdentity, ElementRef, Snapshot};
@@ -81,6 +84,28 @@ impl NetworkLog {
     }
 }
 
+async fn next_event(
+    rx: &mut tokio::sync::broadcast::Receiver<CdpEvent>,
+    cancel: &CancellationToken,
+) -> Option<CdpEvent> {
+    loop {
+        let received = tokio::select! {
+            _ = cancel.cancelled() => return None,
+            received = rx.recv() => received,
+        };
+        match received {
+            Ok(event) => return Some(event),
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                warn!(
+                    skipped,
+                    "CDP event listener lagged; continuing with newest event"
+                );
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
+        }
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum BrowserError {
     #[error("chrome executable not found; set AB_CHROME to its path")]
@@ -89,6 +114,8 @@ pub enum BrowserError {
     Launch(String),
     #[error("failed to discover devtools endpoint: {0}")]
     Discovery(String),
+    #[error("browser profile is already in use: {0}")]
+    ProfileBusy(String),
     #[error("cdp: {0}")]
     Cdp(#[from] ab_cdp::CdpError),
     #[error("unexpected protocol response: {0}")]
@@ -142,12 +169,17 @@ impl Default for LaunchOptions {
 /// The browser process + CDP client.
 pub struct Browser {
     client: CdpClient,
-    child: Option<Child>,
+    child: tokio::sync::Mutex<Option<Child>>,
+    child_pid: Option<u32>,
+    profile_dir: Option<PathBuf>,
     /// UA override applied to new pages (only set in headless+stealth mode).
     user_agent: String,
     /// Whether to normalize the user agent for headless pages.
     inject_stealth: bool,
     input_profile: InputProfile,
+    /// Held for the complete lifetime of a Chrome process launched by us.
+    /// Closing the descriptor releases the OS-enforced profile ownership.
+    profile_lock: tokio::sync::Mutex<Option<ProfileLock>>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -181,6 +213,22 @@ impl Browser {
         self.client.is_connected()
     }
 
+    pub fn is_suspect(&self) -> bool {
+        self.client.is_suspect()
+    }
+
+    pub fn last_transport_error(&self) -> Option<ab_cdp::CdpTransportError> {
+        self.client.last_transport_error()
+    }
+
+    pub fn pid(&self) -> Option<u32> {
+        self.child_pid
+    }
+
+    pub fn profile_dir(&self) -> Option<&std::path::Path> {
+        self.profile_dir.as_deref()
+    }
+
     /// Launch Chrome and connect over CDP.
     ///
     /// Default mode is headful with a persistent profile. Browser-visible
@@ -199,18 +247,9 @@ impl Browser {
             None => default_profile_dir()?,
         };
 
-        // A persistent profile keeps a stale `DevToolsActivePort` from the
-        // previous run; if we read it before the new Chrome rewrites it we get
-        // the wrong port ("no webSocketDebuggerUrl"). Remove it first. Also drop
-        // Singleton* lock files left by an unclean (SIGKILL) exit.
-        for f in [
-            "DevToolsActivePort",
-            "SingletonLock",
-            "SingletonSocket",
-            "SingletonCookie",
-        ] {
-            let _ = std::fs::remove_file(data_dir.join(f));
-        }
+        let profile_lock = ProfileLock::acquire(&data_dir)?;
+
+        profile_lock::prepare_chrome_profile(&data_dir)?;
 
         let mut args: Vec<String> = vec![
             format!("--remote-debugging-port={}", opts.port),
@@ -266,12 +305,16 @@ impl Browser {
             String::new()
         };
 
+        let child_pid = child.id();
         Ok(Self {
             client,
-            child: Some(child),
+            child: tokio::sync::Mutex::new(Some(child)),
+            child_pid,
+            profile_dir: Some(data_dir),
             user_agent,
             inject_stealth,
             input_profile: InputProfile::sample(),
+            profile_lock: tokio::sync::Mutex::new(Some(profile_lock)),
         })
     }
 
@@ -288,10 +331,13 @@ impl Browser {
             .await?;
         Ok(Self {
             client,
-            child: None,
+            child: tokio::sync::Mutex::new(None),
+            child_pid: None,
+            profile_dir: None,
             user_agent: String::new(),
             inject_stealth: false,
             input_profile: InputProfile::sample(),
+            profile_lock: tokio::sync::Mutex::new(None),
         })
     }
 
@@ -365,21 +411,50 @@ impl Browser {
             target_id: target_id.to_string(),
             frame_sessions: Arc::new(Mutex::new(HashMap::new())),
             #[cfg(target_os = "macos")]
-            browser_pid: self.child.as_ref().and_then(Child::id),
+            browser_pid: self.child_pid,
             pointer: Arc::new(Mutex::new(None)),
             pointer_mutation: Arc::new(tokio::sync::Mutex::new(())),
             dialog: Arc::new(Mutex::new((true, None))),
             dialog_handler_started: Arc::new(AtomicBool::new(false)),
             routes: Arc::new(Mutex::new(RouteState::default())),
             input_profile: self.input_profile,
+            lifecycle: Arc::new(PageLifecycle::default()),
         })
     }
 
     /// Terminate the browser process (only if we launched it; connect() no-op).
-    pub async fn close(mut self) {
-        if let Some(child) = self.child.as_mut() {
-            let _ = self.client.send("Browser.close", json!({})).await;
-            let _ = child.kill().await;
+    pub async fn close(&self) {
+        let child = self.child.lock().await.take();
+        if let Some(mut child) = child {
+            let _ = tokio::time::timeout(
+                Duration::from_secs(2),
+                self.client.send("Browser.close", json!({})),
+            )
+            .await;
+            let mut exited = matches!(
+                tokio::time::timeout(Duration::from_secs(3), child.wait()).await,
+                Ok(Ok(_))
+            );
+            if !exited {
+                if let Err(error) = child.start_kill() {
+                    warn!(%error, "failed to kill Chrome after graceful shutdown timeout");
+                }
+                exited = matches!(
+                    tokio::time::timeout(Duration::from_secs(2), child.wait()).await,
+                    Ok(Ok(_))
+                );
+            }
+            let profile_lock = self.profile_lock.lock().await.take();
+            if exited {
+                drop(profile_lock);
+            } else if let Some(profile_lock) = profile_lock {
+                // Fail closed. Releasing ownership without proving process exit
+                // can start two Chromes against one persistent profile.
+                warn!(
+                    "Chrome exit could not be confirmed; retaining profile lock until process exit"
+                );
+                std::mem::forget(profile_lock);
+            }
         }
     }
 }
@@ -648,6 +723,18 @@ pub struct Page {
     routes: Arc<Mutex<RouteState>>,
     /// Stable latent input characteristics shared by all actions on this page.
     input_profile: InputProfile,
+    lifecycle: Arc<PageLifecycle>,
+}
+
+#[derive(Default)]
+struct PageLifecycle {
+    cancel: CancellationToken,
+}
+
+impl Drop for PageLifecycle {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -668,8 +755,15 @@ impl Page {
         &self.target_id
     }
 
+    /// Whether two handles refer to the exact attached-page lifetime. Target
+    /// ids and owner aliases may be reused after a browser generation change.
+    pub fn same_identity(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.lifecycle, &other.lifecycle)
+    }
+
     /// Close this tab at the browser target level.
     pub async fn close(&self) -> Result<()> {
+        self.lifecycle.cancel.cancel();
         self.client
             .send("Target.closeTarget", json!({ "targetId": self.target_id }))
             .await?;
@@ -2405,8 +2499,9 @@ impl Page {
         let mut rx = self.client.events();
         let sid = self.session_id.clone();
         let l = log.clone();
+        let cancel = self.lifecycle.cancel.clone();
         tokio::spawn(async move {
-            while let Ok(ev) = rx.recv().await {
+            while let Some(ev) = next_event(&mut rx, &cancel).await {
                 if ev.session_id.as_deref() != Some(&sid) {
                     continue;
                 }
@@ -2924,8 +3019,9 @@ impl Page {
         let mut rx = self.client.events();
         let sid = self.session_id.clone();
         let l = log.clone();
+        let cancel = self.lifecycle.cancel.clone();
         tokio::spawn(async move {
-            while let Ok(ev) = rx.recv().await {
+            while let Some(ev) = next_event(&mut rx, &cancel).await {
                 if ev.session_id.as_deref() != Some(&sid) {
                     continue;
                 }
@@ -3276,8 +3372,9 @@ impl Page {
         let sid = self.session_id.clone();
         let client = self.client.clone();
         let policy = self.dialog.clone();
+        let cancel = self.lifecycle.cancel.clone();
         tokio::spawn(async move {
-            while let Ok(ev) = rx.recv().await {
+            while let Some(ev) = next_event(&mut rx, &cancel).await {
                 if ev.session_id.as_deref() == Some(&sid)
                     && ev.method == "Page.javascriptDialogOpening"
                 {
@@ -3408,9 +3505,10 @@ impl Page {
             let sid = self.session_id.clone();
             let client = self.client.clone();
             let routes = self.routes.clone();
+            let cancel = self.lifecycle.cancel.clone();
             tokio::spawn(async move {
                 use base64::Engine;
-                while let Ok(ev) = rx.recv().await {
+                while let Some(ev) = next_event(&mut rx, &cancel).await {
                     if ev.session_id.as_deref() != Some(&sid) || ev.method != "Fetch.requestPaused"
                     {
                         continue;
@@ -3919,9 +4017,10 @@ mod tests {
         collect_piercing_query_roots, drag_step_probability, fitts_duration_ms, minimum_jerk,
         movement_step_count, parse_key_combo, paste_probability, require_frame_chain,
         resolve_frame_id, shortcut_command, should_paste_text_for_draw, split_frame_chain,
-        type_ahead_key, us_qwerty_key, FrameAction, KeyCombo, KeyModifier, ReadMode,
+        type_ahead_key, us_qwerty_key, FrameAction, KeyCombo, KeyModifier, PageLifecycle, ReadMode,
     };
     use serde_json::json;
+    use std::sync::Arc;
 
     #[test]
     fn logistic_paste_choice_is_centered_on_equal_cost() {
@@ -3941,6 +4040,17 @@ mod tests {
             0.18,
             0.5
         ));
+    }
+
+    #[test]
+    fn dropping_the_last_page_lifecycle_cancels_listeners() {
+        let lifecycle = Arc::new(PageLifecycle::default());
+        let cancel = lifecycle.cancel.clone();
+        let second_page_handle = lifecycle.clone();
+        drop(lifecycle);
+        assert!(!cancel.is_cancelled());
+        drop(second_page_handle);
+        assert!(cancel.is_cancelled());
     }
 
     #[test]

--- a/crates/ab-browser/src/profile_lock.rs
+++ b/crates/ab-browser/src/profile_lock.rs
@@ -1,0 +1,172 @@
+use std::fs::{self, File, OpenOptions};
+use std::path::{Path, PathBuf};
+
+use fs2::FileExt;
+
+use crate::{BrowserError, Result};
+
+pub(crate) struct ProfileLock {
+    _file: File,
+    path: PathBuf,
+}
+
+impl std::fmt::Debug for ProfileLock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProfileLock")
+            .field("path", &self.path)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for ProfileLock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self._file);
+    }
+}
+
+impl ProfileLock {
+    pub(crate) fn acquire(data_dir: &Path) -> Result<Self> {
+        fs::create_dir_all(data_dir)
+            .map_err(|e| BrowserError::Launch(format!("create profile directory: {e}")))?;
+        let path = data_dir.join(".browser-rs.lock");
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .map_err(|e| BrowserError::Launch(format!("open {}: {e}", path.display())))?;
+        file.try_lock_exclusive()
+            .map_err(|e| BrowserError::ProfileBusy(format!("{} ({e})", data_dir.display())))?;
+        Ok(Self { _file: file, path })
+    }
+}
+
+pub(crate) fn prepare_chrome_profile(data_dir: &Path) -> Result<()> {
+    ensure_no_live_singleton(data_dir)?;
+
+    // DevToolsActivePort is not Chrome's ownership lock. Once profile
+    // ownership is established it is safe to remove a stale endpoint file.
+    remove_if_exists(&data_dir.join("DevToolsActivePort"))?;
+
+    Ok(())
+}
+
+fn remove_if_exists(path: &Path) -> Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(BrowserError::Launch(format!(
+            "remove stale {}: {e}",
+            path.display()
+        ))),
+    }
+}
+
+#[cfg(unix)]
+fn ensure_no_live_singleton(data_dir: &Path) -> Result<()> {
+    let path = data_dir.join("SingletonLock");
+    let target = match fs::read_link(&path) {
+        Ok(target) => target,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(BrowserError::ProfileBusy(format!(
+                "cannot verify {}: {e}",
+                path.display()
+            )))
+        }
+    };
+    let target = target.to_str().ok_or_else(|| {
+        BrowserError::ProfileBusy(format!("{} has a non-UTF-8 target", path.display()))
+    })?;
+    let pid = target
+        .rsplit_once('-')
+        .and_then(|(_, pid)| pid.parse::<i32>().ok())
+        .filter(|pid| *pid > 0)
+        .ok_or_else(|| {
+            BrowserError::ProfileBusy(format!(
+                "{} has an unrecognized target {target:?}",
+                path.display()
+            ))
+        })?;
+
+    if process_is_alive(pid) {
+        return Err(BrowserError::ProfileBusy(format!(
+            "{} is held by Chrome pid {pid}",
+            data_dir.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn process_is_alive(pid: i32) -> bool {
+    use nix::errno::Errno;
+    use nix::sys::signal::kill;
+    use nix::unistd::Pid;
+
+    matches!(kill(Pid::from_raw(pid), None), Ok(()) | Err(Errno::EPERM))
+}
+
+#[cfg(not(unix))]
+fn ensure_no_live_singleton(data_dir: &Path) -> Result<()> {
+    let path = data_dir.join("SingletonLock");
+    if path.exists() {
+        return Err(BrowserError::ProfileBusy(format!(
+            "cannot safely verify {} on this platform",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn profile_lock_is_exclusive_and_released_on_drop() {
+        let dir = tempdir().unwrap();
+        let first = ProfileLock::acquire(dir.path()).unwrap();
+        assert!(matches!(
+            ProfileLock::acquire(dir.path()),
+            Err(BrowserError::ProfileBusy(_))
+        ));
+        drop(first);
+        ProfileLock::acquire(dir.path()).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn live_chrome_singleton_is_never_removed() {
+        let dir = tempdir().unwrap();
+        let singleton = dir.path().join("SingletonLock");
+        symlink(format!("testhost-{}", std::process::id()), &singleton).unwrap();
+
+        assert!(matches!(
+            prepare_chrome_profile(dir.path()),
+            Err(BrowserError::ProfileBusy(_))
+        ));
+        assert!(fs::symlink_metadata(singleton).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stale_chrome_ownership_files_are_left_for_chrome_to_recover() {
+        let dir = tempdir().unwrap();
+        symlink("testhost-2147483647", dir.path().join("SingletonLock")).unwrap();
+        File::create(dir.path().join("SingletonCookie")).unwrap();
+        File::create(dir.path().join("DevToolsActivePort")).unwrap();
+
+        prepare_chrome_profile(dir.path()).unwrap();
+
+        assert!(fs::symlink_metadata(dir.path().join("SingletonLock")).is_ok());
+        assert!(dir.path().join("SingletonCookie").exists());
+        assert!(!dir.path().join("DevToolsActivePort").exists());
+    }
+}

--- a/crates/ab-browser/tests/profile_ownership.rs
+++ b/crates/ab-browser/tests/profile_ownership.rs
@@ -1,0 +1,20 @@
+use ab_browser::{Browser, BrowserError, LaunchOptions};
+
+#[tokio::test]
+#[ignore = "requires a locally installed Chrome or Chromium"]
+async fn one_profile_allows_only_one_live_chrome_owner() {
+    let profile = tempfile::tempdir().unwrap();
+    let options = || LaunchOptions {
+        headless: true,
+        user_data_dir: Some(profile.path().to_path_buf()),
+        ..Default::default()
+    };
+
+    let first = Browser::launch(options()).await.unwrap();
+    let second = Browser::launch(options()).await;
+    assert!(matches!(second, Err(BrowserError::ProfileBusy(_))));
+
+    first.close().await;
+    let replacement = Browser::launch(options()).await.unwrap();
+    replacement.close().await;
+}

--- a/crates/ab-cdp/Cargo.toml
+++ b/crates/ab-cdp/Cargo.toml
@@ -14,6 +14,8 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+tokio-util.workspace = true
+arc-swap.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/ab-cdp/src/lib.rs
+++ b/crates/ab-cdp/src/lib.rs
@@ -7,15 +7,17 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex, Weak};
 use std::time::Duration;
 
+use arc_swap::ArcSwapOption;
 use futures_util::{SinkExt, StreamExt};
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{json, Value};
 use tokio::sync::{broadcast, oneshot, Mutex};
 use tokio::time::{timeout_at, Instant};
 use tokio_tungstenite::tungstenite::Message;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, trace, warn};
 
 #[derive(Debug, thiserror::Error)]
@@ -26,6 +28,8 @@ pub enum CdpError {
     Closed,
     #[error("request timed out after {0:?}")]
     Timeout(Duration),
+    #[error("session command stalled after {0:?}")]
+    Stalled(Duration),
     #[error("cdp protocol error: {0}")]
     Protocol(String),
     #[error("json: {0}")]
@@ -42,6 +46,15 @@ pub struct CdpEvent {
     pub params: Value,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CdpTransportError {
+    pub kind: String,
+    pub phase: String,
+    pub method: Option<String>,
+    pub at_ms: u64,
+}
+
 type Pending = oneshot::Sender<Result<Value>>;
 type CdpSink = futures_util::stream::SplitSink<
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
@@ -51,14 +64,26 @@ type CdpSink = futures_util::stream::SplitSink<
 struct Inner {
     next_id: AtomicU64,
     /// Liveness of the underlying WebSocket. Set to `false` the moment the
-    /// reader task observes a close/error, a write fails, or a request times
-    /// out. Read atomically so health probes never contend on `sink`/`pending`
-    /// -- a probe must not block behind an in-flight CDP request.
+    /// reader observes a close/error, a write fails, a writer stalls, or the
+    /// diagnostic probe confirms an unanswered command reflects transport
+    /// loss. Read atomically so health never contends on `sink`/`pending`.
     connected: AtomicBool,
-    pending: Mutex<HashMap<u64, Pending>>,
+    suspect: AtomicBool,
+    pending: StdMutex<HashMap<u64, Pending>>,
     sink: Mutex<Option<CdpSink>>,
     events: broadcast::Sender<CdpEvent>,
     request_timeout: Duration,
+    transport_timeout: Duration,
+    probe_timeout: Duration,
+    probe_inflight: AtomicBool,
+    reader_cancel: CancellationToken,
+    last_error: ArcSwapOption<CdpTransportError>,
+}
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        self.reader_cancel.cancel();
+    }
 }
 
 impl Inner {
@@ -69,12 +94,14 @@ impl Inner {
     /// must never become a new unbounded wait behind a stalled writer.
     async fn invalidate(self: &Arc<Self>, held_sink: Option<&mut Option<CdpSink>>) {
         {
-            let mut pending = self.pending.lock().await;
+            let mut pending = self.pending.lock().unwrap_or_else(|e| e.into_inner());
             self.connected.store(false, Ordering::SeqCst);
+            self.suspect.store(false, Ordering::Release);
             for (_, tx) in pending.drain() {
                 let _ = tx.send(Err(CdpError::Closed));
             }
         }
+        self.reader_cancel.cancel();
 
         match held_sink {
             Some(sink) => {
@@ -95,6 +122,42 @@ impl Inner {
             }
         }
     }
+
+    fn record_error(&self, kind: &str, phase: &str, method: Option<&str>) {
+        let at_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        self.last_error.store(Some(Arc::new(CdpTransportError {
+            kind: kind.to_string(),
+            phase: phase.to_string(),
+            method: method.map(str::to_string),
+            at_ms,
+        })));
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ResponseTimeoutPolicy {
+    Probe { session_scoped: bool },
+    Invalidate,
+}
+
+struct PendingRegistration {
+    inner: Weak<Inner>,
+    id: u64,
+}
+
+impl Drop for PendingRegistration {
+    fn drop(&mut self) {
+        if let Some(inner) = self.inner.upgrade() {
+            inner
+                .pending
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .remove(&self.id);
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -105,37 +168,63 @@ pub struct CdpClient {
 impl CdpClient {
     /// Connect to a CDP WebSocket debugger URL (ws://host:port/devtools/browser/<id>).
     pub async fn connect(ws_url: &str) -> Result<Self> {
-        let (ws, _resp) = tokio_tungstenite::connect_async(ws_url)
-            .await
-            .map_err(|e| CdpError::Connect(e.to_string()))?;
+        const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+        let (ws, _resp) =
+            tokio::time::timeout(CONNECT_TIMEOUT, tokio_tungstenite::connect_async(ws_url))
+                .await
+                .map_err(|_| CdpError::Connect(format!("timed out after {CONNECT_TIMEOUT:?}")))?
+                .map_err(|e| CdpError::Connect(e.to_string()))?;
         let (sink, mut stream) = ws.split();
         let (events_tx, _) = broadcast::channel(4096);
 
         let inner = Arc::new(Inner {
             next_id: AtomicU64::new(1),
             connected: AtomicBool::new(true),
-            pending: Mutex::new(HashMap::new()),
+            suspect: AtomicBool::new(false),
+            pending: StdMutex::new(HashMap::new()),
             sink: Mutex::new(Some(sink)),
             events: events_tx,
             request_timeout: Duration::from_secs(30),
+            transport_timeout: Duration::from_secs(10),
+            probe_timeout: Duration::from_secs(5),
+            probe_inflight: AtomicBool::new(false),
+            reader_cancel: CancellationToken::new(),
+            last_error: ArcSwapOption::empty(),
         });
 
         // Reader task: routes responses to waiters and events to the broadcast.
-        let r = inner.clone();
+        let reader = Arc::downgrade(&inner);
+        let cancel = inner.reader_cancel.clone();
         tokio::spawn(async move {
-            while let Some(msg) = stream.next().await {
+            loop {
+                let msg = tokio::select! {
+                    _ = cancel.cancelled() => return,
+                    msg = stream.next() => msg,
+                };
+                let Some(msg) = msg else { break };
                 match msg {
-                    Ok(Message::Text(txt)) => dispatch(&r, &txt).await,
+                    Ok(Message::Text(txt)) => {
+                        let Some(inner) = reader.upgrade() else {
+                            return;
+                        };
+                        dispatch(&inner, &txt).await;
+                    }
                     Ok(Message::Close(_)) => break,
                     Ok(_) => {}
                     Err(e) => {
+                        if let Some(inner) = reader.upgrade() {
+                            inner.record_error("closed", "reader", None);
+                        }
                         warn!("cdp reader error: {e}");
                         break;
                     }
                 }
             }
             // Chrome is gone (close frame, transport error, or EOF).
-            r.invalidate(None).await;
+            if let Some(inner) = reader.upgrade() {
+                inner.record_error("closed", "reader", None);
+                inner.invalidate(None).await;
+            }
         });
 
         Ok(Self { inner })
@@ -154,6 +243,17 @@ impl CdpClient {
         self.inner.connected.load(Ordering::SeqCst)
     }
 
+    pub fn is_suspect(&self) -> bool {
+        self.inner.suspect.load(Ordering::Acquire)
+    }
+
+    pub fn last_transport_error(&self) -> Option<CdpTransportError> {
+        self.inner
+            .last_error
+            .load_full()
+            .map(|error| error.as_ref().clone())
+    }
+
     /// Subscribe to the raw CDP event stream.
     pub fn events(&self) -> broadcast::Receiver<CdpEvent> {
         self.inner.events.subscribe()
@@ -161,12 +261,30 @@ impl CdpClient {
 
     /// Send a browser-scoped CDP command.
     pub async fn send(&self, method: &str, params: Value) -> Result<Value> {
-        self.send_inner(method, params, None).await
+        self.send_inner(
+            method,
+            params,
+            None,
+            self.inner.request_timeout,
+            ResponseTimeoutPolicy::Probe {
+                session_scoped: false,
+            },
+        )
+        .await
     }
 
     /// Send a command scoped to a page/target session (flatten mode).
     pub async fn send_on(&self, session_id: &str, method: &str, params: Value) -> Result<Value> {
-        self.send_inner(method, params, Some(session_id)).await
+        self.send_inner(
+            method,
+            params,
+            Some(session_id),
+            self.inner.request_timeout,
+            ResponseTimeoutPolicy::Probe {
+                session_scoped: true,
+            },
+        )
+        .await
     }
 
     /// Typed convenience wrapper.
@@ -176,7 +294,18 @@ impl CdpClient {
         method: &str,
         params: Value,
     ) -> Result<T> {
-        let v = self.send_inner(method, params, session_id).await?;
+        let policy = ResponseTimeoutPolicy::Probe {
+            session_scoped: session_id.is_some(),
+        };
+        let v = self
+            .send_inner(
+                method,
+                params,
+                session_id,
+                self.inner.request_timeout,
+                policy,
+            )
+            .await?;
         Ok(serde_json::from_value(v)?)
     }
 
@@ -185,11 +314,15 @@ impl CdpClient {
         method: &str,
         params: Value,
         session_id: Option<&str>,
+        request_timeout: Duration,
+        response_policy: ResponseTimeoutPolicy,
     ) -> Result<Value> {
         // One deadline covers queueing for the shared writer, writing the
         // command, and waiting for Chrome's response. Starting a fresh timeout
         // only after `sink.send()` allowed a blocked writer to hang forever.
-        let deadline = Instant::now() + self.inner.request_timeout;
+        let started_at = Instant::now();
+        let deadline = started_at + request_timeout;
+        let transport_deadline = (started_at + self.inner.transport_timeout).min(deadline);
         let id = self.inner.next_id.fetch_add(1, Ordering::SeqCst);
         let mut msg = json!({ "id": id, "method": method, "params": params });
         if let Some(sid) = session_id {
@@ -202,27 +335,33 @@ impl CdpClient {
         // window: the reader could close and drain in between.
         let (tx, rx) = oneshot::channel();
         {
-            let mut pending = self.inner.pending.lock().await;
+            let mut pending = self.inner.pending.lock().unwrap_or_else(|e| e.into_inner());
             if !self.inner.connected.load(Ordering::SeqCst) {
                 return Err(CdpError::Closed);
             }
             pending.insert(id, tx);
         }
+        let _registration = PendingRegistration {
+            inner: Arc::downgrade(&self.inner),
+            id,
+        };
 
         {
-            let mut guard = match timeout_at(deadline, self.inner.sink.lock()).await {
+            let mut guard = match timeout_at(transport_deadline, self.inner.sink.lock()).await {
                 Ok(guard) => guard,
                 Err(_) => {
+                    self.inner
+                        .record_error("timeout", "writer-lock", Some(method));
                     warn!(
                         request_id = id,
                         method,
                         session_id,
-                        timeout_ms = self.inner.request_timeout.as_millis() as u64,
+                        timeout_ms = self.inner.transport_timeout.as_millis() as u64,
                         phase = "writer-lock",
                         "cdp request timed out; invalidating transport"
                     );
                     self.inner.invalidate(None).await;
-                    return Err(CdpError::Timeout(self.inner.request_timeout));
+                    return Err(CdpError::Timeout(self.inner.transport_timeout));
                 }
             };
             if !self.inner.connected.load(Ordering::SeqCst) {
@@ -234,9 +373,10 @@ impl CdpClient {
             };
             let text = serde_json::to_string(&msg)?;
             trace!("-> {text}");
-            match timeout_at(deadline, sink.send(Message::Text(text))).await {
+            match timeout_at(transport_deadline, sink.send(Message::Text(text))).await {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => {
+                    self.inner.record_error("write", "write", Some(method));
                     // A write failure means the socket is unusable even if the
                     // reader task has not observed the close yet.
                     self.inner.invalidate(Some(&mut *guard)).await;
@@ -244,16 +384,17 @@ impl CdpClient {
                     return Err(CdpError::Closed);
                 }
                 Err(_) => {
+                    self.inner.record_error("timeout", "write", Some(method));
                     warn!(
                         request_id = id,
                         method,
                         session_id,
-                        timeout_ms = self.inner.request_timeout.as_millis() as u64,
+                        timeout_ms = self.inner.transport_timeout.as_millis() as u64,
                         phase = "write",
                         "cdp request timed out; invalidating transport"
                     );
                     self.inner.invalidate(Some(&mut *guard)).await;
-                    return Err(CdpError::Timeout(self.inner.request_timeout));
+                    return Err(CdpError::Timeout(self.inner.transport_timeout));
                 }
             }
         }
@@ -262,21 +403,68 @@ impl CdpClient {
             Ok(Ok(res)) => res,
             Ok(Err(_)) => Err(CdpError::Closed),
             Err(_) => {
-                // An unanswered command means this transport can no longer be
-                // trusted. Invalidate every shared client instead of leaving
-                // them attached to a half-open socket.
+                self.inner.record_error("timeout", "response", Some(method));
                 warn!(
                     request_id = id,
                     method,
                     session_id,
-                    timeout_ms = self.inner.request_timeout.as_millis() as u64,
+                    timeout_ms = request_timeout.as_millis() as u64,
                     phase = "response",
-                    "cdp request timed out; invalidating transport"
+                    "cdp response timed out"
                 );
-                self.inner.invalidate(None).await;
-                Err(CdpError::Timeout(self.inner.request_timeout))
+                match response_policy {
+                    ResponseTimeoutPolicy::Probe { session_scoped } => {
+                        self.inner.suspect.store(true, Ordering::Release);
+                        self.spawn_probe_if_idle();
+                        if session_scoped {
+                            Err(CdpError::Stalled(request_timeout))
+                        } else {
+                            Err(CdpError::Timeout(request_timeout))
+                        }
+                    }
+                    ResponseTimeoutPolicy::Invalidate => {
+                        self.inner.invalidate(None).await;
+                        Err(CdpError::Timeout(request_timeout))
+                    }
+                }
             }
         }
+    }
+
+    fn spawn_probe_if_idle(&self) {
+        if self
+            .inner
+            .probe_inflight
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        let client = self.clone();
+        tokio::spawn(async move {
+            let timeout = client.inner.probe_timeout;
+            let result = client
+                .send_inner(
+                    "Browser.getVersion",
+                    json!({}),
+                    None,
+                    timeout,
+                    ResponseTimeoutPolicy::Invalidate,
+                )
+                .await;
+            match result {
+                Ok(_) => {
+                    client.inner.suspect.store(false, Ordering::Release);
+                    debug!("transport probe succeeded after response timeout");
+                }
+                Err(error) => {
+                    warn!(%error, "transport probe failed after response timeout");
+                    client.inner.invalidate(None).await;
+                }
+            }
+            client.inner.probe_inflight.store(false, Ordering::Release);
+        });
     }
 }
 
@@ -292,7 +480,12 @@ async fn dispatch(inner: &Arc<Inner>, txt: &str) {
 
     // Response to a command (has "id").
     if let Some(id) = v.get("id").and_then(Value::as_u64) {
-        if let Some(tx) = inner.pending.lock().await.remove(&id) {
+        if let Some(tx) = inner
+            .pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&id)
+        {
             if let Some(err) = v.get("error") {
                 let _ = tx.send(Err(CdpError::Protocol(err.to_string())));
             } else {
@@ -333,7 +526,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(start_paused = true)]
+    #[tokio::test]
     async fn request_timeout_invalidates_transport_and_releases_all_waiters() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -352,7 +545,11 @@ mod tests {
         let (waiter_one_tx, waiter_one_rx) = oneshot::channel();
         let (waiter_two_tx, waiter_two_rx) = oneshot::channel();
         {
-            let mut pending = client.inner.pending.lock().await;
+            let mut pending = client
+                .inner
+                .pending
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             pending.insert(10_001, waiter_one_tx);
             pending.insert(10_002, waiter_two_tx);
         }
@@ -361,6 +558,7 @@ mod tests {
         let first = tokio::spawn(async move { first_client.send("Test.first", json!({})).await });
         requests.recv().await.unwrap();
         drop(client.inner.sink.lock().await);
+        tokio::time::pause();
 
         tokio::time::advance(Duration::from_secs(30)).await;
         tokio::task::yield_now().await;
@@ -369,6 +567,14 @@ mod tests {
             first.await.unwrap(),
             Err(CdpError::Timeout(duration)) if duration == Duration::from_secs(30)
         ));
+
+        // A browser-scoped response timeout is only suspicion. The dedicated
+        // five-second probe must fail before the shared transport is closed.
+        requests.recv().await.unwrap();
+        drop(client.inner.sink.lock().await);
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(5)).await;
+        tokio::task::yield_now().await;
         assert!(matches!(
             waiter_one_rx.await.unwrap(),
             Err(CdpError::Closed)
@@ -378,7 +584,13 @@ mod tests {
             Err(CdpError::Closed)
         ));
         assert!(!client.is_connected());
-        assert!(client.inner.pending.lock().await.is_empty());
+        assert!(client.inner.reader_cancel.is_cancelled());
+        assert!(client
+            .inner
+            .pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .is_empty());
         assert!(client.inner.sink.lock().await.is_none());
         assert!(matches!(
             client.send("Test.later", json!({})).await,
@@ -388,7 +600,7 @@ mod tests {
         server.abort();
     }
 
-    #[tokio::test(start_paused = true)]
+    #[tokio::test]
     async fn writer_lock_timeout_returns_without_waiting_for_the_lock_holder() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -400,6 +612,7 @@ mod tests {
 
         let client = CdpClient::connect(&format!("ws://{addr}")).await.unwrap();
         let sink_guard = client.inner.sink.lock().await;
+        tokio::time::pause();
         let blocked_client = client.clone();
         let blocked =
             tokio::spawn(async move { blocked_client.send("Test.blocked", json!({})).await });
@@ -407,20 +620,31 @@ mod tests {
         // Wait until the request is registered and blocked on the held writer
         // lock before advancing its single end-to-end deadline.
         loop {
-            if !client.inner.pending.lock().await.is_empty() {
+            if !client
+                .inner
+                .pending
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .is_empty()
+            {
                 break;
             }
             tokio::task::yield_now().await;
         }
-        tokio::time::advance(Duration::from_secs(30)).await;
+        tokio::time::advance(Duration::from_secs(10)).await;
         tokio::task::yield_now().await;
 
         assert!(matches!(
             blocked.await.unwrap(),
-            Err(CdpError::Timeout(duration)) if duration == Duration::from_secs(30)
+            Err(CdpError::Timeout(duration)) if duration == Duration::from_secs(10)
         ));
         assert!(!client.is_connected());
-        assert!(client.inner.pending.lock().await.is_empty());
+        assert!(client
+            .inner
+            .pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .is_empty());
 
         // Invalidation returns before this guard is released. Its detached
         // cleanup then removes the sink as soon as the holder exits.
@@ -432,6 +656,108 @@ mod tests {
             Err(CdpError::Closed)
         ));
 
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn session_stall_keeps_other_owners_connected() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (method_tx, mut methods) = mpsc::unbounded_channel();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut websocket = accept_async(stream).await.unwrap();
+            while let Some(Ok(Message::Text(text))) = websocket.next().await {
+                let request: Value = serde_json::from_str(&text).unwrap();
+                let method = request["method"].as_str().unwrap().to_string();
+                if method != "Test.stalledPage" {
+                    websocket
+                        .send(Message::Text(
+                            json!({ "id": request["id"], "result": {} }).to_string(),
+                        ))
+                        .await
+                        .unwrap();
+                }
+                method_tx.send(method).unwrap();
+            }
+        });
+
+        let client = CdpClient::connect(&format!("ws://{addr}")).await.unwrap();
+        let stalled_client = client.clone();
+        let stalled = tokio::spawn(async move {
+            stalled_client
+                .send_on("owner-a", "Test.stalledPage", json!({}))
+                .await
+        });
+        assert_eq!(methods.recv().await.as_deref(), Some("Test.stalledPage"));
+        drop(client.inner.sink.lock().await);
+        tokio::time::pause();
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(30)).await;
+        tokio::task::yield_now().await;
+
+        assert!(matches!(
+            stalled.await.unwrap(),
+            Err(CdpError::Stalled(duration)) if duration == Duration::from_secs(30)
+        ));
+        assert!(client.is_connected());
+
+        tokio::time::resume();
+        assert_eq!(methods.recv().await.as_deref(), Some("Browser.getVersion"));
+        while client.inner.probe_inflight.load(Ordering::Acquire) {
+            tokio::task::yield_now().await;
+        }
+        assert!(client.is_connected());
+
+        let healthy_client = client.clone();
+        let healthy = tokio::spawn(async move {
+            healthy_client
+                .send_on("owner-b", "Test.followup", json!({}))
+                .await
+        });
+        assert_eq!(methods.recv().await.as_deref(), Some("Test.followup"));
+        assert_eq!(healthy.await.unwrap().unwrap(), json!({}));
+        assert!(client.is_connected());
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn cancelling_a_request_removes_its_pending_entry() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (request_tx, mut requests) = mpsc::unbounded_channel();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut websocket = accept_async(stream).await.unwrap();
+            while let Some(message) = websocket.next().await {
+                if message.unwrap().is_text() {
+                    request_tx.send(()).unwrap();
+                }
+            }
+        });
+
+        let client = CdpClient::connect(&format!("ws://{addr}")).await.unwrap();
+        let pending_client = client.clone();
+        let request = tokio::spawn(async move {
+            pending_client
+                .send_on("owner-a", "Test.cancelled", json!({}))
+                .await
+        });
+        requests.recv().await.unwrap();
+        request.abort();
+        let _ = request.await;
+
+        let pending_ids: Vec<u64> = client
+            .inner
+            .pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .keys()
+            .copied()
+            .collect();
+        assert!(pending_ids.is_empty(), "pending ids: {pending_ids:?}");
+        assert!(client.is_connected());
         server.abort();
     }
 }

--- a/crates/ab-mcp/Cargo.toml
+++ b/crates/ab-mcp/Cargo.toml
@@ -29,3 +29,4 @@ hmac.workspace = true
 sha2.workspace = true
 rand.workspace = true
 tokio-util.workspace = true
+arc-swap.workspace = true

--- a/crates/ab-mcp/src/http_security.rs
+++ b/crates/ab-mcp/src/http_security.rs
@@ -112,6 +112,23 @@ impl HttpSecurity {
             return Ok(None);
         }
 
+        if is_admin_path(&path) {
+            let Some(root) = self.root_capability.as_deref() else {
+                return Err(Box::new(unauthorized(
+                    "browser administrative capability is unavailable",
+                )));
+            };
+            if !provided
+                .as_deref()
+                .is_some_and(|value| constant_time_eq(value, root))
+            {
+                return Err(Box::new(unauthorized(
+                    "invalid browser administrative capability",
+                )));
+            }
+            return Ok(None);
+        }
+
         if !self.managed {
             if let Some(expected) = self.root_capability.as_deref() {
                 if !provided
@@ -127,18 +144,6 @@ impl HttpSecurity {
         let Some(root) = self.root_capability.as_deref() else {
             return Err(Box::new(unauthorized("browser capability is unavailable")));
         };
-        if path == "/owners" {
-            if !provided
-                .as_deref()
-                .is_some_and(|value| constant_time_eq(value, root))
-            {
-                return Err(Box::new(unauthorized(
-                    "invalid browser administrative capability",
-                )));
-            }
-            return Ok(None);
-        }
-
         let Some(owner) = owner else {
             return Err(Box::new(
                 (StatusCode::BAD_REQUEST, "browser owner is required").into_response(),
@@ -176,6 +181,10 @@ impl HttpSecurity {
             Entry::Occupied(entry) => entry.get() == &owner,
         }
     }
+}
+
+fn is_admin_path(path: &str) -> bool {
+    path == "/owners" || path == "/admin/drain" || path == "/admin/relaunch"
 }
 
 pub fn owner_capability(root: &str, owner: &str) -> String {
@@ -338,32 +347,60 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn owners_endpoint_accepts_only_the_root_capability() {
+    async fn administrative_endpoints_accept_only_the_root_capability() {
         let security = managed_security();
         let owner_token = owner_capability("root-secret", "owner-a");
-        let owner_request = Request::builder()
-            .uri("/owners?owner=owner-a")
-            .header(CAPABILITY_HEADER, owner_token)
+        for path in [
+            "/owners?owner=owner-a",
+            "/admin/drain",
+            "/admin/relaunch?expected_generation=1",
+        ] {
+            let owner_request = Request::builder()
+                .uri(path)
+                .header(CAPABILITY_HEADER, &owner_token)
+                .body(Body::empty())
+                .unwrap();
+            assert_eq!(
+                security
+                    .authorize_request(request_auth(&owner_request))
+                    .await
+                    .unwrap_err()
+                    .status(),
+                StatusCode::UNAUTHORIZED
+            );
+
+            let root_request = Request::builder()
+                .uri(path)
+                .header(CAPABILITY_HEADER, "root-secret")
+                .body(Body::empty())
+                .unwrap();
+            assert!(security
+                .authorize_request(request_auth(&root_request))
+                .await
+                .is_ok());
+        }
+    }
+
+    #[tokio::test]
+    async fn standalone_admin_is_disabled_without_a_root_capability() {
+        let security = HttpSecurity {
+            managed: false,
+            root_capability: None,
+            spawn_nonce: None,
+            session_owners: Default::default(),
+        };
+        let request = Request::builder()
+            .uri("/admin/drain")
             .body(Body::empty())
             .unwrap();
         assert_eq!(
             security
-                .authorize_request(request_auth(&owner_request))
+                .authorize_request(request_auth(&request))
                 .await
                 .unwrap_err()
                 .status(),
             StatusCode::UNAUTHORIZED
         );
-
-        let root_request = Request::builder()
-            .uri("/owners?owner=owner-a")
-            .header(CAPABILITY_HEADER, "root-secret")
-            .body(Body::empty())
-            .unwrap();
-        assert!(security
-            .authorize_request(request_auth(&root_request))
-            .await
-            .is_ok());
     }
 
     #[tokio::test]

--- a/crates/ab-mcp/src/main.rs
+++ b/crates/ab-mcp/src/main.rs
@@ -5,13 +5,15 @@
 //!
 //! Core loop the tools encode: **snapshot -> act -> verify**.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock, Weak};
 
 use ab_browser::{
     Browser, ConsoleLog, ElementRef, LaunchOptions, NetworkLog, Page, PointerAction,
     PointerLocation, PointerRequest,
 };
+use arc_swap::ArcSwap;
 use rmcp::handler::server::{router::tool::ToolRouter, tool::ToolCallContext, wrapper::Parameters};
 use rmcp::model::{
     CallToolRequestParams, CallToolResult, ClientJsonRpcMessage, ContentBlock, ListToolsResult,
@@ -144,6 +146,8 @@ struct WebAuthnConfig {
 }
 
 struct PageEntry {
+    generation: u64,
+    stalled_at_ms: Option<u64>,
     page: Page,
     refs: HashMap<String, ElementRef>,
     last_text: String,
@@ -236,9 +240,18 @@ fn truncate_text(mut value: String, limit: usize) -> String {
     value
 }
 
-#[derive(Default)]
 struct State {
-    browser: Option<Browser>,
+    browser: Option<Arc<Browser>>,
+    retired_browser: Option<Arc<Browser>>,
+    browser_generation: u64,
+    draining: bool,
+    browser_lifecycle: Arc<Mutex<()>>,
+    external_page_sync: Arc<Mutex<()>>,
+    launching: bool,
+    health: Arc<HealthState>,
+    recovery_attempts: VecDeque<std::time::Instant>,
+    recovery_cooldown_until: Option<std::time::Instant>,
+    recovery_required: bool,
     pages: HashMap<String, PageEntry>,
     /// Stable caller-selected aliases for pages. This lets an agent claim pN
     /// once and use its owner name in every later `page` argument.
@@ -257,6 +270,122 @@ struct State {
     lost_owners: HashSet<String>,
 }
 
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            browser: None,
+            retired_browser: None,
+            browser_generation: 0,
+            draining: false,
+            browser_lifecycle: Arc::new(Mutex::new(())),
+            external_page_sync: Arc::new(Mutex::new(())),
+            launching: false,
+            health: Arc::new(HealthState::new()),
+            recovery_attempts: VecDeque::new(),
+            recovery_cooldown_until: None,
+            recovery_required: false,
+            pages: HashMap::new(),
+            owners: HashMap::new(),
+            page_owners: HashMap::new(),
+            next: 0,
+            lost_owners: HashSet::new(),
+        }
+    }
+}
+
+const HEALTH_ABSENT: u8 = 0;
+const HEALTH_LAUNCHING: u8 = 1;
+const HEALTH_READY: u8 = 2;
+const HEALTH_DEAD: u8 = 3;
+const HEALTH_DRAINING: u8 = 4;
+
+struct HealthState {
+    snapshot: ArcSwap<HealthSnapshot>,
+    inflight_tools: AtomicU64,
+    spawn_nonce: String,
+    started_at: std::time::Instant,
+}
+
+struct HealthSnapshot {
+    browser: Option<Arc<Browser>>,
+    generation: u64,
+    state: u8,
+    pages: u64,
+    stalled_pages: u64,
+    draining: bool,
+    recovery_attempts: Vec<std::time::Instant>,
+    cooldown_until: Option<std::time::Instant>,
+}
+
+impl HealthState {
+    fn new() -> Self {
+        Self {
+            snapshot: ArcSwap::from_pointee(HealthSnapshot {
+                browser: None,
+                generation: 0,
+                state: HEALTH_ABSENT,
+                pages: 0,
+                stalled_pages: 0,
+                draining: false,
+                recovery_attempts: Vec::new(),
+                cooldown_until: None,
+            }),
+            inflight_tools: AtomicU64::new(0),
+            spawn_nonce: random_token(),
+            started_at: std::time::Instant::now(),
+        }
+    }
+
+    fn publish(&self, state: &State) {
+        let browser = state
+            .browser
+            .clone()
+            .or_else(|| state.retired_browser.clone());
+        let lifecycle_state = if state.draining {
+            HEALTH_DRAINING
+        } else if state.launching {
+            HEALTH_LAUNCHING
+        } else if state
+            .browser
+            .as_ref()
+            .is_some_and(|browser| browser.is_connected())
+        {
+            HEALTH_READY
+        } else if state.browser.is_some() || state.retired_browser.is_some() {
+            HEALTH_DEAD
+        } else {
+            HEALTH_ABSENT
+        };
+        self.snapshot.store(Arc::new(HealthSnapshot {
+            browser,
+            generation: state.browser_generation,
+            state: lifecycle_state,
+            pages: state.pages.len() as u64,
+            stalled_pages: state
+                .pages
+                .values()
+                .filter(|entry| entry.stalled_at_ms.is_some())
+                .count() as u64,
+            draining: state.draining,
+            recovery_attempts: state.recovery_attempts.iter().copied().collect(),
+            cooldown_until: state.recovery_cooldown_until,
+        }));
+    }
+
+    fn begin_tool(self: &Arc<Self>) -> InflightToolGuard {
+        self.inflight_tools.fetch_add(1, Ordering::AcqRel);
+        InflightToolGuard(self.clone())
+    }
+}
+
+struct InflightToolGuard(Arc<HealthState>);
+
+impl Drop for InflightToolGuard {
+    fn drop(&mut self) {
+        self.0.inflight_tools.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
 /// Key used for pages opened outside any owner scope (`request_owner() == None`).
 /// A real owner cannot collide with it: owners are caller-supplied identifiers
 /// and this one is not a legal MCP owner string.
@@ -265,11 +394,18 @@ const UNSCOPED_OWNER: &str = "\u{0}unscoped";
 /// Outcome of resolving a caller-supplied page id, decided in one critical
 /// section so the answer cannot be invalidated before it is acted on.
 enum PageLookup {
-    Found(Page),
+    Found(PageLease),
     /// The page is gone because the browser died. Recoverable by reopening.
     Lost,
     /// No such page for this caller, on a browser that is working fine.
     Unknown,
+}
+
+#[derive(Clone)]
+struct PageLease {
+    page_id: String,
+    generation: u64,
+    page: Page,
 }
 
 #[derive(Clone)]
@@ -390,6 +526,11 @@ struct ClaimPageArgs {
 struct OwnerArg {
     /// Owner alias previously registered with browser_claim_page.
     owner: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RelaunchQuery {
+    expected_generation: u64,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -761,7 +902,48 @@ fn ok(s: impl Into<String>) -> CallToolResult {
 }
 
 fn fail<E: std::fmt::Display>(e: E) -> McpError {
-    McpError::internal_error(e.to_string(), None)
+    let message = e.to_string();
+    let class = if message.contains("session command stalled") {
+        Some("page_stalled")
+    } else if message.contains("transport closed") || message.contains("browser was lost") {
+        Some("transport_lost")
+    } else if message.contains("browser generation changed") {
+        Some("stale_generation")
+    } else if message.contains("browser profile is already in use") {
+        Some("profile_busy")
+    } else if message.contains("recovery circuit") {
+        Some("recovery_circuit_open")
+    } else if message.contains("request timed out") {
+        Some("browser_suspect")
+    } else {
+        None
+    };
+    McpError::internal_error(
+        message,
+        class.map(|class| serde_json::json!({ "class": class })),
+    )
+}
+
+fn enrich_browser_error(mut error: McpError, health: &HealthState) -> McpError {
+    let snapshot = health.snapshot.load_full();
+    let connected = snapshot
+        .browser
+        .as_ref()
+        .is_some_and(|browser| browser.is_connected());
+    let generation = snapshot.generation;
+    if let Some(data) = error
+        .data
+        .as_mut()
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        if data.get("class").and_then(serde_json::Value::as_str) == Some("browser_suspect")
+            && !connected
+        {
+            data.insert("class".into(), serde_json::json!("transport_lost"));
+        }
+        data.insert("generation".into(), serde_json::json!(generation));
+    }
+    error
 }
 
 fn validate_wheel_input(delta_y: f64, x: f64, y: f64) -> Result<(), &'static str> {
@@ -843,7 +1025,7 @@ impl BrowserServer {
         if st
             .browser
             .as_ref()
-            .is_none_or(ab_browser::Browser::is_connected)
+            .is_none_or(|browser| browser.is_connected())
         {
             return false;
         }
@@ -862,9 +1044,117 @@ impl BrowserServer {
         st.page_owners.clear();
         // Drop without `close()`: Chrome is already gone, so the shutdown
         // handshake would just block on the dead socket.
-        st.browser = None;
+        st.retired_browser = st.browser.take();
+        st.recovery_required = true;
+        st.health.publish(st);
         warn!("cdp transport lost; discarded dead browser and {lost_pages} page handle(s)");
         true
+    }
+
+    fn admit_recovery(st: &mut State) -> Result<(), McpError> {
+        const WINDOW: std::time::Duration = std::time::Duration::from_secs(10 * 60);
+        const COOLDOWN: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+        const MAX_ATTEMPTS: usize = 3;
+
+        let now = std::time::Instant::now();
+        while st
+            .recovery_attempts
+            .front()
+            .is_some_and(|attempt| now.duration_since(*attempt) >= WINDOW)
+        {
+            st.recovery_attempts.pop_front();
+        }
+        if let Some(until) = st.recovery_cooldown_until {
+            if until > now {
+                st.health.publish(st);
+                return Err(fail("browser recovery circuit is open"));
+            }
+            // One half-open attempt starts a fresh observation window.
+            st.recovery_attempts.clear();
+            st.recovery_cooldown_until = None;
+        }
+        if st.recovery_attempts.len() >= MAX_ATTEMPTS {
+            st.recovery_cooldown_until = Some(now + COOLDOWN);
+            st.health.publish(st);
+            return Err(fail("browser recovery circuit opened for 5 minutes"));
+        }
+        st.recovery_attempts.push_back(now);
+        st.health.publish(st);
+        Ok(())
+    }
+
+    /// Return one live browser generation, launching at most once. The
+    /// lifecycle mutex serializes only launch/reap; no State guard crosses
+    /// process or CDP I/O.
+    async fn ensure_browser(&self) -> Result<(Arc<Browser>, u64, bool), McpError> {
+        let lifecycle = { self.state.lock().await.browser_lifecycle.clone() };
+        let _lifecycle = lifecycle.lock().await;
+        let (existing, generation, retired, recovered, recovery_required, draining) = {
+            let mut st = self.state.lock().await;
+            let recovered = Self::reap_dead_browser(&mut st);
+            if st.browser.is_none() && !st.draining {
+                st.launching = true;
+            }
+            st.health.publish(&st);
+            (
+                st.browser.clone(),
+                st.browser_generation,
+                st.retired_browser.take(),
+                recovered,
+                st.recovery_required,
+                st.draining,
+            )
+        };
+
+        if draining {
+            return Err(fail("browser process is draining"));
+        }
+        if let Some(browser) = existing {
+            return Ok((browser, generation, recovered));
+        }
+        if recovery_required {
+            let mut st = self.state.lock().await;
+            if let Err(error) = Self::admit_recovery(&mut st) {
+                st.launching = false;
+                st.health.publish(&st);
+                return Err(error);
+            }
+        }
+        if let Some(browser) = retired {
+            browser.close().await;
+        }
+
+        let browser = match make_browser().await {
+            Ok(browser) => Arc::new(browser),
+            Err(error) => {
+                let mut st = self.state.lock().await;
+                st.launching = false;
+                st.health.publish(&st);
+                return Err(fail(error));
+            }
+        };
+        let mut st = self.state.lock().await;
+        st.launching = false;
+        if st.draining {
+            st.health.publish(&st);
+            drop(st);
+            browser.close().await;
+            return Err(fail("browser process is draining"));
+        }
+        if let Some(existing) = st.browser.as_ref() {
+            let existing = existing.clone();
+            let generation = st.browser_generation;
+            st.health.publish(&st);
+            drop(st);
+            browser.close().await;
+            return Ok((existing, generation, recovered));
+        }
+        st.browser_generation = st.browser_generation.wrapping_add(1).max(1);
+        let generation = st.browser_generation;
+        st.browser = Some(browser.clone());
+        st.recovery_required = false;
+        st.health.publish(&st);
+        Ok((browser, generation, recovered || recovery_required))
     }
 
     /// Identity used to scope loss bookkeeping for the current request.
@@ -887,10 +1177,27 @@ impl BrowserServer {
     async fn lookup_page(&self, id: &str) -> PageLookup {
         let mut st = self.state.lock().await;
         Self::reap_dead_browser(&mut st);
-        let page = Self::resolve_page_id(&st, id)
-            .and_then(|page_id| st.pages.get(&page_id).map(|entry| entry.page.clone()));
+        let resolved_page_id = Self::resolve_page_id(&st, id);
+        let (page, stale_generation) = resolved_page_id
+            .as_ref()
+            .and_then(|page_id| st.pages.get(page_id))
+            .map_or((None, false), |entry| {
+                if entry.generation == st.browser_generation {
+                    (
+                        Some(PageLease {
+                            page_id: resolved_page_id.clone().unwrap_or_default(),
+                            generation: entry.generation,
+                            page: entry.page.clone(),
+                        }),
+                        false,
+                    )
+                } else {
+                    (None, true)
+                }
+            });
         match page {
             Some(page) => PageLookup::Found(page),
+            None if stale_generation => PageLookup::Lost,
             None if Self::caller_lost_pages(&st) => PageLookup::Lost,
             None => PageLookup::Unknown,
         }
@@ -938,13 +1245,25 @@ impl BrowserServer {
 
     /// Clone the Page for a given id/owner (does not hold the lock across ops).
     async fn page_of(&self, id: &str) -> Result<Page, McpError> {
+        Ok(self.page_lease_of(id).await?.page)
+    }
+
+    async fn page_lease_of(&self, id: &str) -> Result<PageLease, McpError> {
         match self.lookup_page(id).await {
-            PageLookup::Found(page) => Ok(page),
+            PageLookup::Found(lease) => Ok(lease),
             PageLookup::Lost | PageLookup::Unknown => {
                 let st = self.state.lock().await;
                 Err(Self::unresolved_page_error(&st, id))
             }
         }
+    }
+
+    async fn matching_page_lease(&self, id: &str, page: &Page) -> Result<PageLease, McpError> {
+        let lease = self.page_lease_of(id).await?;
+        if !lease.page.same_identity(page) {
+            return Err(fail("browser generation changed during page operation"));
+        }
+        Ok(lease)
     }
 
     async fn begin_typing(
@@ -1083,24 +1402,36 @@ impl BrowserServer {
     }
 
     /// Persist a fresh snapshot (refs + text) for a page.
-    async fn store_snapshot(&self, id: &str, refs: HashMap<String, ElementRef>, text: String) {
+    async fn store_snapshot(
+        &self,
+        lease: &PageLease,
+        refs: HashMap<String, ElementRef>,
+        text: String,
+    ) -> Result<(), McpError> {
         let mut st = self.state.lock().await;
-        let Some(page_id) = Self::resolve_page_id(&st, id) else {
-            return;
-        };
-        if let Some(e) = st.pages.get_mut(&page_id) {
-            e.refs = refs;
-            e.last_text = text;
+        if st.browser_generation != lease.generation {
+            return Err(fail("browser generation changed before snapshot commit"));
         }
+        let Some(entry) = st.pages.get_mut(&lease.page_id).filter(|entry| {
+            entry.generation == lease.generation && entry.page.same_identity(&lease.page)
+        }) else {
+            return Err(fail("browser generation changed before snapshot commit"));
+        };
+        entry.refs = refs;
+        entry.last_text = text;
+        Ok(())
     }
 
-    async fn last_text(&self, id: &str) -> String {
+    async fn last_text(&self, lease: &PageLease) -> String {
         let st = self.state.lock().await;
-        let Some(page_id) = Self::resolve_page_id(&st, id) else {
+        if st.browser_generation != lease.generation {
             return String::new();
-        };
+        }
         st.pages
-            .get(&page_id)
+            .get(&lease.page_id)
+            .filter(|entry| {
+                entry.generation == lease.generation && entry.page.same_identity(&lease.page)
+            })
             .map(|e| e.last_text.clone())
             .unwrap_or_default()
     }
@@ -1150,26 +1481,29 @@ impl BrowserServer {
 
     /// Import tabs created by page JavaScript or target=_blank into the MCP page map.
     async fn sync_external_pages(&self) -> Result<Vec<String>, McpError> {
-        let mut st = self.state.lock().await;
-        // Reap rather than skip. Merely ignoring a dead browser left the page
-        // maps intact, so `browser_tabs` (which calls this first) and
-        // `browser_status` kept advertising pages that no longer existed until
-        // some unrelated call happened to reap.
-        Self::reap_dead_browser(&mut st);
-        let Some(browser) = st.browser.as_ref() else {
-            return Ok(Vec::new());
+        let sync = { self.state.lock().await.external_page_sync.clone() };
+        let _sync = sync.lock().await;
+        let (browser, generation, known, target_to_page, page_owners) = {
+            let mut st = self.state.lock().await;
+            Self::reap_dead_browser(&mut st);
+            let Some(browser) = st.browser.clone() else {
+                return Ok(Vec::new());
+            };
+            (
+                browser,
+                st.browser_generation,
+                st.pages
+                    .values()
+                    .map(|entry| entry.page.target_id().to_string())
+                    .collect::<std::collections::HashSet<_>>(),
+                st.pages
+                    .iter()
+                    .map(|(page_id, entry)| (entry.page.target_id().to_string(), page_id.clone()))
+                    .collect::<HashMap<_, _>>(),
+                st.page_owners.clone(),
+            )
         };
         let targets = browser.page_targets().await.map_err(fail)?;
-        let known: std::collections::HashSet<String> = st
-            .pages
-            .values()
-            .map(|entry| entry.page.target_id().to_string())
-            .collect();
-        let target_to_page: HashMap<String, String> = st
-            .pages
-            .iter()
-            .map(|(page_id, entry)| (entry.page.target_id().to_string(), page_id.clone()))
-            .collect();
         let new_targets: Vec<(String, String, Option<String>)> = targets
             .into_iter()
             .filter(|(target_id, url, _)| !known.contains(target_id) && url != "about:blank")
@@ -1180,22 +1514,36 @@ impl BrowserServer {
             let inherited_owner = opener_id
                 .as_ref()
                 .and_then(|target_id| target_to_page.get(target_id))
-                .and_then(|page_id| st.page_owners.get(page_id))
+                .and_then(|page_id| page_owners.get(page_id))
                 .cloned();
-            let page = st
-                .browser
-                .as_ref()
-                .unwrap()
-                .attach_page(&target_id)
-                .await
-                .map_err(fail)?;
+            let page = browser.attach_page(&target_id).await.map_err(fail)?;
             let netlog = page.enable_network_log().await.ok();
             let snap = page.snapshot().await.map_err(fail)?;
+            let mut st = self.state.lock().await;
+            if st.browser_generation != generation
+                || st
+                    .browser
+                    .as_ref()
+                    .is_none_or(|current| !Arc::ptr_eq(current, &browser))
+            {
+                drop(st);
+                let _ = page.close().await;
+                return Err(fail("browser generation changed while importing a page"));
+            }
+            if st
+                .pages
+                .values()
+                .any(|entry| entry.page.target_id() == target_id)
+            {
+                continue;
+            }
             st.next += 1;
             let id = format!("p{}", st.next);
             st.pages.insert(
                 id.clone(),
                 PageEntry {
+                    generation,
+                    stalled_at_ms: None,
                     page,
                     refs: snap.refs,
                     last_text: snap.text,
@@ -1210,6 +1558,7 @@ impl BrowserServer {
                 st.page_owners.insert(id.clone(), owner);
             }
             added.push(id);
+            st.health.publish(&st);
         }
         Ok(added)
     }
@@ -1265,40 +1614,37 @@ impl BrowserServer {
     /// Open a fresh tab (launching the browser if needed), navigate it, and
     /// register it. Returns (page_id, snapshot_text).
     async fn open_page(&self, url: &str) -> Result<(String, String), McpError> {
-        let mut st = self.state.lock().await;
-        // Recover from a Chrome that exited under us. `browser_navigate` is the
-        // one tool that does not need a pre-existing page, which makes it the
-        // natural re-entry point: an agent that hits `transport closed` can get
-        // a working browser back by navigating, with no supervisor involvement.
-        let recovered = Self::reap_dead_browser(&mut st);
-        if st.browser.is_none() {
-            st.browser = Some(make_browser().await.map_err(fail)?);
-            if recovered {
-                warn!("relaunched chrome after transport loss");
-            }
+        let (browser, generation, recovered) = self.ensure_browser().await?;
+        if recovered {
+            warn!(generation, "relaunched chrome after transport loss");
         }
-        // Clear only this caller's loss. A relaunch fixes the process for
-        // everyone, but the other owners still have no pages and must keep
-        // being told that, instead of being handed "unknown page".
-        st.lost_owners.remove(&Self::loss_key());
         // Blank page first so the network log captures the navigation itself.
-        let page = st
-            .browser
-            .as_ref()
-            .unwrap()
-            .new_page("about:blank")
-            .await
-            .map_err(fail)?;
+        let page = browser.new_page("about:blank").await.map_err(fail)?;
         let netlog = page.enable_network_log().await.ok();
         if !url.is_empty() && url != "about:blank" {
             page.navigate(url).await.map_err(fail)?;
         }
         let snap = page.snapshot().await.map_err(fail)?;
+        let mut st = self.state.lock().await;
+        if st.browser_generation != generation
+            || st
+                .browser
+                .as_ref()
+                .is_none_or(|current| !Arc::ptr_eq(current, &browser))
+        {
+            drop(st);
+            let _ = page.close().await;
+            return Err(fail("browser generation changed while opening a page"));
+        }
+        // Clear only this caller's loss after a page is successfully committed.
+        st.lost_owners.remove(&Self::loss_key());
         st.next += 1;
         let id = format!("p{}", st.next);
         st.pages.insert(
             id.clone(),
             PageEntry {
+                generation,
+                stalled_at_ms: None,
                 page,
                 refs: snap.refs.clone(),
                 last_text: snap.text.clone(),
@@ -1312,17 +1658,19 @@ impl BrowserServer {
             st.owners.insert(owner.clone(), id.clone());
             st.page_owners.insert(id.clone(), owner);
         }
+        st.health.publish(&st);
         Ok((id, snap.text))
     }
 
     /// After an action: wait for settle, re-snapshot, diff vs the previous
     /// snapshot, persist the new one, and return the diff for the agent.
     async fn settle_diff(&self, id: &str, page: &Page) -> Result<String, McpError> {
-        let before = self.last_text(id).await;
+        let lease = self.matching_page_lease(id, page).await?;
+        let before = self.last_text(&lease).await;
         page.settle().await;
         let snap = page.snapshot().await.map_err(fail)?;
         let diff = snapshot_diff(&before, &snap.text);
-        self.store_snapshot(id, snap.refs, snap.text).await;
+        self.store_snapshot(&lease, snap.refs, snap.text).await?;
         let new_pages = self.sync_external_pages().await?;
         if new_pages.is_empty() {
             Ok(diff)
@@ -1349,11 +1697,11 @@ impl BrowserServer {
             // Fall through to opening a fresh tab; a genuinely unknown page id
             // (no browser loss) still errors.
             match self.lookup_page(pid).await {
-                PageLookup::Found(page) => {
-                    page.navigate(&a.url).await.map_err(fail)?;
-                    let snap = page.snapshot().await.map_err(fail)?;
-                    self.store_snapshot(pid, snap.refs.clone(), snap.text.clone())
-                        .await;
+                PageLookup::Found(lease) => {
+                    lease.page.navigate(&a.url).await.map_err(fail)?;
+                    let snap = lease.page.snapshot().await.map_err(fail)?;
+                    self.store_snapshot(&lease, snap.refs.clone(), snap.text.clone())
+                        .await?;
                     return Ok(ok(format!("page {pid}\nurl {}\n\n{}", a.url, snap.text)));
                 }
                 PageLookup::Unknown => {
@@ -1386,10 +1734,10 @@ impl BrowserServer {
         &self,
         Parameters(a): Parameters<BoundedPageArg>,
     ) -> Result<CallToolResult, McpError> {
-        let page = self.page_of(&a.page).await?;
-        let snap = page.snapshot().await.map_err(fail)?;
-        self.store_snapshot(&a.page, snap.refs.clone(), snap.text.clone())
-            .await;
+        let lease = self.page_lease_of(&a.page).await?;
+        let snap = lease.page.snapshot().await.map_err(fail)?;
+        self.store_snapshot(&lease, snap.refs.clone(), snap.text.clone())
+            .await?;
         let output = format!("page {}\n\n{}", a.page, snap.text);
         Ok(ok(match a.max_length {
             Some(limit) => truncate_text(output, limit),
@@ -2313,6 +2661,7 @@ impl BrowserServer {
         let mut st = self.state.lock().await;
         Self::reap_dead_browser(&mut st);
         let running = st.browser.is_some();
+        let generation = st.browser_generation;
         let open_pages = request_owner().map_or_else(
             || st.pages.len(),
             |owner| {
@@ -2373,7 +2722,7 @@ impl BrowserServer {
             "blocked (strict default)"
         };
         Ok(ok(format!(
-            "running: {running}\nmode: {mode}\ndetectable diagnostics: {detectable_diagnostics}\nopen pages: {open_pages}\nvirtual authenticators: {virtual_authenticators}\ndialog handlers: {dialog_handlers}"
+            "running: {running}\ngeneration: {generation}\nmode: {mode}\ndetectable diagnostics: {detectable_diagnostics}\nopen pages: {open_pages}\nvirtual authenticators: {virtual_authenticators}\ndialog handlers: {dialog_handlers}"
         )))
     }
 
@@ -2401,6 +2750,7 @@ impl BrowserServer {
                 if let Some(e) = st.pages.get_mut(&page_id) {
                     e.consolelog = Some(l.clone());
                 }
+                drop(st);
                 // Give a brief moment for buffered messages after enabling.
                 tokio::time::sleep(std::time::Duration::from_millis(150)).await;
                 l
@@ -2546,10 +2896,10 @@ impl BrowserServer {
         &self,
         Parameters(a): Parameters<PageArg>,
     ) -> Result<CallToolResult, McpError> {
-        let page = self.page_of(&a.page).await?;
-        let snap = page.snapshot().await.map_err(fail)?;
-        self.store_snapshot(&a.page, snap.refs.clone(), snap.text.clone())
-            .await;
+        let lease = self.page_lease_of(&a.page).await?;
+        let snap = lease.page.snapshot().await.map_err(fail)?;
+        self.store_snapshot(&lease, snap.refs.clone(), snap.text.clone())
+            .await?;
         Ok(ok(format!("page {}\n\n{}", a.page, snap.text)))
     }
 
@@ -2581,15 +2931,21 @@ impl BrowserServer {
                 st.page_owners.remove(page_id);
             }
             st.owners.remove(&owner);
+            st.health.publish(&st);
             return Ok(ok(format!("closed {} owner page(s)", closed.len())));
         }
 
+        let lifecycle = { self.state.lock().await.browser_lifecycle.clone() };
+        let _lifecycle = lifecycle.lock().await;
         let browser = {
             let mut st = self.state.lock().await;
             st.pages.clear();
             st.owners.clear();
             st.page_owners.clear();
-            st.browser.take()
+            let browser = st.browser.take().or_else(|| st.retired_browser.take());
+            st.recovery_required = false;
+            st.health.publish(&st);
+            browser
         };
         if let Some(b) = browser {
             b.close().await;
@@ -2740,6 +3096,7 @@ impl BrowserServer {
         if st.pages.remove(&page_id).is_some() {
             st.owners.retain(|_, claimed| claimed != &page_id);
             st.page_owners.remove(&page_id);
+            st.health.publish(&st);
             Ok(ok(format!("closed {page_id}")))
         } else {
             Err(fail(format!("unknown page '{page_id}'")))
@@ -2911,6 +3268,8 @@ impl rmcp::ServerHandler for BrowserServer {
                 None,
             ));
         }
+        let health = { self.state.lock().await.health.clone() };
+        let _inflight = health.begin_tool();
         let owner = context
             .extensions
             .get::<http::request::Parts>()
@@ -2957,21 +3316,81 @@ impl rmcp::ServerHandler for BrowserServer {
         } else {
             None
         };
+        let requested_page = request
+            .arguments
+            .as_ref()
+            .and_then(|arguments| arguments.get("page"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string);
+        let page_marker = if let Some(requested_page) = requested_page.as_deref() {
+            let state = self.state.lock().await;
+            let page_id = if let Some(owner) = owner.as_ref() {
+                if requested_page == owner {
+                    state.owners.get(owner).cloned()
+                } else if state.page_owners.get(requested_page) == Some(owner) {
+                    Some(requested_page.to_string())
+                } else {
+                    None
+                }
+            } else if state.pages.contains_key(requested_page) {
+                Some(requested_page.to_string())
+            } else {
+                state.owners.get(requested_page).cloned()
+            };
+            page_id.and_then(|page_id| {
+                state.pages.get(&page_id).map(|entry| PageLease {
+                    page_id,
+                    generation: entry.generation,
+                    page: entry.page.clone(),
+                })
+            })
+        } else {
+            None
+        };
         let result = REQUEST_OWNER
             .scope(owner, async {
                 self.tool_router
                     .call(ToolCallContext::new(self, request, context))
                     .await
             })
-            .await;
+            .await
+            .map_err(|error| enrich_browser_error(error, &health));
+        if let Some(marker) = page_marker {
+            let stalled = result.as_ref().err().is_some_and(|error| {
+                error
+                    .data
+                    .as_ref()
+                    .and_then(|data| data.get("class"))
+                    .and_then(serde_json::Value::as_str)
+                    == Some("page_stalled")
+            });
+            if stalled || result.is_ok() {
+                let mut state = self.state.lock().await;
+                let generation = state.browser_generation;
+                if let Some(entry) = state.pages.get_mut(&marker.page_id).filter(|entry| {
+                    generation == marker.generation
+                        && entry.generation == marker.generation
+                        && entry.page.same_identity(&marker.page)
+                }) {
+                    entry.stalled_at_ms = stalled.then(|| {
+                        std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_millis() as u64
+                    });
+                }
+                state.health.publish(&state);
+            }
+        }
         let Some((broker, lease, boundary)) = broker_context else {
             return result;
         };
-        let unredacted = match result {
-            Ok(value) => value,
-            Err(error) => CallToolResult::error(vec![ContentBlock::text(error.to_string())]),
-        };
-        let value = serde_json::to_value(unredacted).map_err(|_| {
+        let is_error = result.is_err();
+        let value = match result {
+            Ok(value) => serde_json::to_value(value),
+            Err(error) => serde_json::to_value(error),
+        }
+        .map_err(|_| {
             McpError::internal_error("browser output was blocked before secure redaction", None)
         })?;
         let secured = broker
@@ -2980,9 +3399,15 @@ impl rmcp::ServerHandler for BrowserServer {
             .map_err(|_| {
                 McpError::internal_error("browser output was blocked by secure redaction", None)
             })?;
-        serde_json::from_value(secured).map_err(|_| {
-            McpError::internal_error("secure broker returned invalid browser output", None)
-        })
+        if is_error {
+            Err(serde_json::from_value(secured).map_err(|_| {
+                McpError::internal_error("secure broker returned invalid browser error", None)
+            })?)
+        } else {
+            serde_json::from_value(secured).map_err(|_| {
+                McpError::internal_error("secure broker returned invalid browser output", None)
+            })
+        }
     }
 
     async fn list_tools(
@@ -3077,10 +3502,11 @@ Env equivalents: AB_HTTP, AB_HTTP_CAPABILITY, AB_PROFILE, AB_HEADLESS, AB_NO_STE
 mod tests {
     use super::{
         bind_address_is_loopback, constant_time_secret_eq, enforce_scoped_owner,
-        force_scoped_owner_argument, parse_allowed_tools, parse_cli_from, parse_connect_port,
-        release_owner_claim, snapshot_diff, truncate_text, validate_wheel_input,
-        webdriver_value_is_human, BrowserServer, IframeTypeArgs, State, TypeArgs, WebAuthnConfig,
-        DEFAULT_MAX_OUTPUT_LIMIT, REQUEST_OWNER,
+        enrich_browser_error, fail, force_scoped_owner_argument, parse_allowed_tools,
+        parse_cli_from, parse_connect_port, release_owner_claim, snapshot_diff, truncate_text,
+        validate_wheel_input, webdriver_value_is_human, BrowserServer, IframeTypeArgs, State,
+        TypeArgs, WebAuthnConfig, DEFAULT_MAX_OUTPUT_LIMIT, HEALTH_DRAINING, HEALTH_LAUNCHING,
+        REQUEST_OWNER,
     };
     use rmcp::model::CallToolRequestParams;
 
@@ -3442,6 +3868,74 @@ mod tests {
         assert!(webdriver_value_is_human(&serde_json::json!("false")));
         assert!(!webdriver_value_is_human(&serde_json::json!("true")));
     }
+
+    #[test]
+    fn health_snapshot_tracks_launching_and_draining_without_state_lock() {
+        let mut state = State {
+            launching: true,
+            ..Default::default()
+        };
+        let health = state.health.clone();
+        health.publish(&state);
+        assert_eq!(health.snapshot.load().state, HEALTH_LAUNCHING);
+
+        state.launching = false;
+        state.draining = true;
+        health.publish(&state);
+        let snapshot = health.snapshot.load();
+        assert_eq!(snapshot.state, HEALTH_DRAINING);
+        assert!(snapshot.draining);
+    }
+
+    #[test]
+    fn browser_errors_include_a_machine_readable_class_and_generation() {
+        let state = State {
+            browser_generation: 7,
+            ..Default::default()
+        };
+        state.health.publish(&state);
+        let error = enrich_browser_error(fail("session command stalled after 30s"), &state.health);
+        let data = error.data.unwrap();
+        assert_eq!(data["class"], "page_stalled");
+        assert_eq!(data["generation"], 7);
+    }
+
+    #[tokio::test]
+    async fn draining_state_rejects_launch_without_starting_chrome() {
+        let server = BrowserServer::new();
+        {
+            let mut state = server.state.lock().await;
+            state.draining = true;
+            state.health.publish(&state);
+        }
+        let error = match server.ensure_browser().await {
+            Ok(_) => panic!("draining state unexpectedly launched Chrome"),
+            Err(error) => error,
+        };
+        assert!(error.message.contains("draining"));
+    }
+
+    #[test]
+    fn recovery_circuit_opens_after_three_attempts_in_ten_minutes() {
+        let mut state = State::default();
+        assert!(BrowserServer::admit_recovery(&mut state).is_ok());
+        assert!(BrowserServer::admit_recovery(&mut state).is_ok());
+        assert!(BrowserServer::admit_recovery(&mut state).is_ok());
+        let error = BrowserServer::admit_recovery(&mut state).unwrap_err();
+        assert!(error.message.contains("circuit opened"));
+        assert!(state.recovery_cooldown_until.is_some());
+        let snapshot = state.health.snapshot.load();
+        assert_eq!(snapshot.recovery_attempts.len(), 3);
+        assert!(snapshot.cooldown_until.is_some());
+
+        state.recovery_cooldown_until = Some(
+            std::time::Instant::now()
+                .checked_sub(std::time::Duration::from_secs(1))
+                .unwrap(),
+        );
+        assert!(BrowserServer::admit_recovery(&mut state).is_ok());
+        assert_eq!(state.recovery_attempts.len(), 1);
+    }
 }
 
 struct Cli {
@@ -3562,6 +4056,7 @@ struct SseState {
     /// Process-wide browser state shared across all SSE sessions, so Chrome
     /// stays resident between turns (each turn opens a fresh SSE connection).
     browser: Arc<Mutex<State>>,
+    health: Arc<HealthState>,
     security: http_security::HttpSecurity,
     secret_broker: Option<secret_broker::SecretBroker>,
 }
@@ -3733,48 +4228,227 @@ async fn sse_post(
 /// still succeeds, so a transport-level probe reports healthy while every
 /// browser tool fails against a closed CDP socket.
 ///
-/// `try_lock` is deliberate. The browser mutex is held for the duration of an
-/// in-flight tool call (navigations can run for tens of seconds), and a health
-/// endpoint that blocks behind it would report a timeout — causing exactly the
-/// spurious restarts this is meant to prevent. A contended lock is reported as
-/// an unknown verdict rather than a healthy one: the lock is also held during
-/// a cold start and during a call stuck on a dead socket, so "busy" says
-/// nothing about whether Chrome is attached.
+/// Health reads only atomics and an ArcSwap browser handle. It never waits for
+/// the State mutex or CDP, so a supervisor can distinguish a busy profile from
+/// a dead transport without creating another queue behind the failed command.
 async fn health(
     axum::extract::State(state): axum::extract::State<SseState>,
 ) -> axum::Json<serde_json::Value> {
     let mut payload = state.security.health();
-    let browser = match state.browser.try_lock() {
-        Ok(st) => match st.browser.as_ref() {
-            Some(browser) => serde_json::json!({
-                "launched": true,
-                "connected": browser.is_connected(),
-                "pages": st.pages.len(),
-            }),
-            None => serde_json::json!({
-                "launched": false,
-                "connected": false,
-                "pages": 0,
-            }),
-        },
-        // Contended: a tool call holds the browser mutex. That is *not*
-        // evidence the browser is alive — `open_page` holds this lock across
-        // `make_browser()` and across CDP calls, so the contended window
-        // covers both a cold start with no browser yet and a request blocked
-        // on a socket whose Chrome already exited. Reporting `connected:true`
-        // here manufactured health for up to the 30s CDP timeout and hid the
-        // exact fault this endpoint exists to expose. Say "unknown" instead;
-        // supervisors treat a missing verdict as "do not act".
-        Err(_) => serde_json::json!({
-            "launched": serde_json::Value::Null,
-            "connected": serde_json::Value::Null,
-            "busy": true,
-        }),
+    let health = &state.health;
+    let snapshot = health.snapshot.load_full();
+    let browser_handle = snapshot.browser.clone();
+    let mut state_name = match snapshot.state {
+        HEALTH_LAUNCHING => "launching",
+        HEALTH_READY => "ready",
+        HEALTH_DEAD => "dead",
+        HEALTH_DRAINING => "draining",
+        _ => "absent",
     };
+    let connected = browser_handle
+        .as_ref()
+        .map(|browser| browser.is_connected());
+    if state_name == "ready" {
+        if connected == Some(false) {
+            state_name = "dead";
+        } else if browser_handle
+            .as_ref()
+            .is_some_and(|browser| browser.is_suspect())
+        {
+            state_name = "suspect";
+        }
+    }
+    let chrome_pid = browser_handle.as_ref().and_then(|browser| browser.pid());
+    let profile_dir = browser_handle
+        .as_ref()
+        .and_then(|browser| browser.profile_dir())
+        .map(|path| path.display().to_string());
+    let last_transport_error = browser_handle
+        .as_ref()
+        .and_then(|browser| browser.last_transport_error());
+    let browser = serde_json::json!({
+        "state": state_name,
+        "generation": snapshot.generation,
+        "launched": browser_handle.is_some(),
+        "connected": connected,
+        "chromePid": chrome_pid,
+        "profileDir": profile_dir,
+        "pages": snapshot.pages,
+        "lastTransportError": last_transport_error,
+    });
     if let Some(map) = payload.as_object_mut() {
+        map.insert("schema".to_string(), serde_json::json!(2));
+        map.insert(
+            "version".to_string(),
+            serde_json::json!(env!("CARGO_PKG_VERSION")),
+        );
+        map.entry("spawnNonce".to_string())
+            .or_insert_with(|| serde_json::json!(health.spawn_nonce));
+        map.insert(
+            "process".to_string(),
+            serde_json::json!({
+                "pid": std::process::id(),
+                "uptimeMs": health.started_at.elapsed().as_millis() as u64,
+                "draining": snapshot.draining,
+            }),
+        );
+        map.insert(
+            "inflight".to_string(),
+            serde_json::json!({ "tools": health.inflight_tools.load(Ordering::Acquire) }),
+        );
+        map.insert(
+            "pages".to_string(),
+            serde_json::json!({
+                "total": snapshot.pages,
+                "stalled": snapshot.stalled_pages,
+            }),
+        );
+        let now = std::time::Instant::now();
+        let attempts_in_window = snapshot
+            .recovery_attempts
+            .iter()
+            .filter(|attempt| now.duration_since(**attempt) < std::time::Duration::from_secs(600))
+            .count();
+        let cooldown_until_ms = snapshot
+            .cooldown_until
+            .and_then(|until| until.checked_duration_since(now))
+            .map(|remaining| {
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .saturating_add(remaining)
+                    .as_millis() as u64
+            });
+        map.insert(
+            "recovery".to_string(),
+            serde_json::json!({
+                "inProgress": state_name == "launching",
+                "attemptsInWindow": attempts_in_window,
+                "cooldownUntilMs": cooldown_until_ms,
+            }),
+        );
         map.insert("browser".to_string(), browser);
     }
     axum::Json(payload)
+}
+
+async fn admin_drain(
+    axum::extract::State(state): axum::extract::State<SseState>,
+) -> (axum::http::StatusCode, axum::Json<serde_json::Value>) {
+    use axum::http::StatusCode;
+
+    let lifecycle = { state.browser.lock().await.browser_lifecycle.clone() };
+    let _lifecycle = lifecycle.lock().await;
+    let browsers = {
+        let mut st = state.browser.lock().await;
+        st.draining = true;
+        st.launching = false;
+        st.pages.clear();
+        st.owners.clear();
+        st.page_owners.clear();
+        st.recovery_required = false;
+        let browsers = [st.browser.take(), st.retired_browser.take()];
+        st.health.publish(&st);
+        browsers
+    };
+    for browser in browsers.into_iter().flatten() {
+        browser.close().await;
+    }
+    (
+        StatusCode::OK,
+        axum::Json(serde_json::json!({ "ok": true, "state": "draining" })),
+    )
+}
+
+async fn admin_relaunch(
+    axum::extract::State(state): axum::extract::State<SseState>,
+    axum::extract::Query(query): axum::extract::Query<RelaunchQuery>,
+) -> (axum::http::StatusCode, axum::Json<serde_json::Value>) {
+    use axum::http::StatusCode;
+
+    let lifecycle = { state.browser.lock().await.browser_lifecycle.clone() };
+    let _lifecycle = lifecycle.lock().await;
+    let old_browser = {
+        let mut st = state.browser.lock().await;
+        if st.draining {
+            return (
+                StatusCode::LOCKED,
+                axum::Json(serde_json::json!({ "ok": false, "error": "draining" })),
+            );
+        }
+        if st.browser_generation != query.expected_generation {
+            return (
+                StatusCode::CONFLICT,
+                axum::Json(serde_json::json!({
+                    "ok": false,
+                    "error": "generation_mismatch",
+                    "expectedGeneration": query.expected_generation,
+                    "generation": st.browser_generation,
+                })),
+            );
+        }
+        if let Err(error) = BrowserServer::admit_recovery(&mut st) {
+            return (
+                StatusCode::TOO_MANY_REQUESTS,
+                axum::Json(serde_json::json!({
+                    "ok": false,
+                    "error": error.message,
+                    "class": "recovery_circuit_open",
+                    "generation": st.browser_generation,
+                })),
+            );
+        }
+        for owner in st.page_owners.values().cloned().collect::<Vec<_>>() {
+            st.lost_owners.insert(owner);
+        }
+        st.pages.clear();
+        st.owners.clear();
+        st.page_owners.clear();
+        st.launching = true;
+        st.recovery_required = true;
+        let browser = st.browser.take().or_else(|| st.retired_browser.take());
+        st.health.publish(&st);
+        browser
+    };
+    if let Some(browser) = old_browser {
+        browser.close().await;
+    }
+
+    let browser = match make_browser().await {
+        Ok(browser) => Arc::new(browser),
+        Err(error) => {
+            let mut st = state.browser.lock().await;
+            st.launching = false;
+            st.health.publish(&st);
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                axum::Json(serde_json::json!({ "ok": false, "error": error.to_string() })),
+            );
+        }
+    };
+    let generation = {
+        let mut st = state.browser.lock().await;
+        if st.draining {
+            st.launching = false;
+            st.health.publish(&st);
+            drop(st);
+            browser.close().await;
+            return (
+                StatusCode::LOCKED,
+                axum::Json(serde_json::json!({ "ok": false, "error": "draining" })),
+            );
+        }
+        st.browser_generation = st.browser_generation.wrapping_add(1).max(1);
+        st.launching = false;
+        st.browser = Some(browser);
+        st.recovery_required = false;
+        st.health.publish(&st);
+        st.browser_generation
+    };
+    (
+        StatusCode::OK,
+        axum::Json(serde_json::json!({ "ok": true, "generation": generation })),
+    )
 }
 
 async fn close_owner_pages(
@@ -3820,6 +4494,7 @@ async fn close_owner_pages(
         st.page_owners.remove(page_id);
     }
     st.owners.remove(owner);
+    st.health.publish(&st);
 
     (
         StatusCode::OK,
@@ -3869,6 +4544,7 @@ async fn serve_http(addr: &str) -> anyhow::Result<()> {
     // the SSE state for the whole process lifetime, so the browser is never
     // dropped between sessions — only when the server process exits.
     let shared_state: Arc<Mutex<State>> = Arc::new(Mutex::new(State::default()));
+    let shared_health = shared_state.lock().await.health.clone();
     let secret_broker = secret_broker::SecretBroker::from_env()?;
 
     let mcp_state = shared_state.clone();
@@ -3892,6 +4568,7 @@ async fn serve_http(addr: &str) -> anyhow::Result<()> {
     let sse_state = SseState {
         sessions: Arc::new(Mutex::new(HashMap::new())),
         browser: shared_state,
+        health: shared_health,
         security: security.clone(),
         secret_broker: secret_broker.clone(),
     };
@@ -3907,6 +4584,8 @@ async fn serve_http(addr: &str) -> anyhow::Result<()> {
         .route("/sse", axum::routing::get(sse_get))
         .route("/message", axum::routing::post(sse_post))
         .route("/owners", axum::routing::delete(close_owner_pages))
+        .route("/admin/drain", axum::routing::post(admin_drain))
+        .route("/admin/relaunch", axum::routing::post(admin_relaunch))
         .nest_service("/mcp", service)
         .with_state(sse_state.clone())
         .layer(auth_layer);
@@ -3914,8 +4593,13 @@ async fn serve_http(addr: &str) -> anyhow::Result<()> {
     let listener = tokio::net::TcpListener::bind(&bind).await?;
     info!("browser-rs MCP server on http://{bind}/mcp (streamable HTTP) + http://{bind}/sse (legacy SSE)");
     let shutdown_sessions = sse_state.sessions.clone();
+    let shutdown_browser = sse_state.browser.clone();
     axum::serve(listener, router)
-        .with_graceful_shutdown(shutdown_signal(shutdown_sessions, cancellation_token))
+        .with_graceful_shutdown(shutdown_signal(
+            shutdown_sessions,
+            shutdown_browser,
+            cancellation_token,
+        ))
         .await?;
 
     let browser = {
@@ -3923,7 +4607,12 @@ async fn serve_http(addr: &str) -> anyhow::Result<()> {
         state.pages.clear();
         state.page_owners.clear();
         state.owners.clear();
-        state.browser.take()
+        let browser = state
+            .browser
+            .take()
+            .or_else(|| state.retired_browser.take());
+        state.health.publish(&state);
+        browser
     };
     if let Some(browser) = browser {
         browser.close().await;
@@ -3933,6 +4622,7 @@ async fn serve_http(addr: &str) -> anyhow::Result<()> {
 
 async fn shutdown_signal(
     sessions: SseSessions,
+    browser: Arc<Mutex<State>>,
     cancellation_token: tokio_util::sync::CancellationToken,
 ) {
     #[cfg(unix)]
@@ -3958,6 +4648,11 @@ async fn shutdown_signal(
             }
         }
         _ = terminate => {}
+    }
+    {
+        let mut state = browser.lock().await;
+        state.draining = true;
+        state.health.publish(&state);
     }
     cancellation_token.cancel();
     sessions.lock().await.clear();


### PR DESCRIPTION
## Summary

- apply finite deadlines to CDP connect, writer lock, write, and response waits
- classify session response timeouts as page stalls and confirm transport death with a single diagnostic probe
- cancel pending requests and listener tasks without lock-order deadlocks
- enforce one live Chrome owner per profile with an OS lock and fail-closed Singleton inspection
- move Chrome/CDP I/O outside the process-wide MCP state mutex
- reject stale results with browser generation and attached-page identity checks
- publish a coherent lock-free schema-2 health snapshot with process epoch, generation, lifecycle, page stalls, and recovery state
- add root-capability-only generation-CAS relaunch/drain endpoints and a bounded recovery circuit breaker
- preserve structured lifecycle errors through the managed secret broker

## Safety properties

- one stalled page does not invalidate unrelated owners or pending commands
- EOF, write failure, writer-lock timeout, or failed browser probe invalidates the shared transport and wakes all waiters
- old-generation operations cannot commit into replacement pages through reused owner aliases
- health cannot mix a previous browser handle with a replacement generation
- browser-rs never deletes Chrome Singleton ownership files
- profile ownership is retained unless Chrome exit is confirmed
- repeated recovery cannot create an unbounded kill/relaunch loop

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test --workspace` (83 passed; 3 Chrome-required tests ignored by default)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p ab-browser --test profile_ownership -- --ignored` (real Chrome, passed)
- release workspace build
- native-surface benchmark: 16/16
- live HTTP verification: schema-2 health, generation 0 -> 1 relaunch, stale generation HTTP 409, drain transition, unauthenticated standalone admin HTTP 401

## Rollout

This PR does not deploy or replace production binaries. Production remains pinned to browser-rs v0.3.1 until a separate canary rollout is approved.
